### PR TITLE
Isolate-backed match cache and client-server pattern

### DIFF
--- a/bin/db_oneoff_impl/export_miffs_command.dart
+++ b/bin/db_oneoff_impl/export_miffs_command.dart
@@ -43,7 +43,7 @@ class ExportMiffsCommand extends DbOneoffCommand {
     var allMatches = await db.getAllMatches();
     var exporter = MiffExporter();
     for(var match in allMatches) {
-      var hydratedRes = match.hydrate();
+      var hydratedRes = match.hydrateSync();
       if(hydratedRes.isErr()) {
         console.print("Error hydrating match ${match.id}: ${hydratedRes.unwrapErr().message}");
         continue;

--- a/bin/db_oneoff_impl/ties.dart
+++ b/bin/db_oneoff_impl/ties.dart
@@ -40,7 +40,7 @@ class TiesCommand extends DbOneoffCommand {
         continue;
       }
       var dbMatch = dbMatchRes.unwrap();
-      var matchRes = await dbMatch.hydrate(useCache: true);
+      var matchRes = await dbMatch.hydrateSync(useCache: true);
       if(matchRes.isErr()) {
         console.print("Error hydrating match: ${matchRes.unwrapErr()}");
         continue;

--- a/bin/db_oneoff_impl/winning_points_by_date_command.dart
+++ b/bin/db_oneoff_impl/winning_points_by_date_command.dart
@@ -50,7 +50,7 @@ Future<void> _winningPointsByDate(AnalystDatabase db, Console console) async {
       console.print("Sport has no divisions: ${match.eventName}");
       return;
     }
-    var hydratedMatchRes = await match.hydrate(useCache: true);
+    var hydratedMatchRes = await match.hydrateSync(useCache: true);
     if(hydratedMatchRes.isErr()) {
         console.print("Error hydrating match: ${hydratedMatchRes.unwrapErr()}");
       continue;

--- a/lib/data/cache/match/isolate_match_cache.dart
+++ b/lib/data/cache/match/isolate_match_cache.dart
@@ -12,39 +12,42 @@ import "package:shooting_sports_analyst/data/database/analyst_database.dart";
 import "package:shooting_sports_analyst/data/database/match/hydrated_cache.dart";
 import "package:shooting_sports_analyst/data/database/schema/match.dart";
 import "package:shooting_sports_analyst/data/sport/match/match.dart";
+import "package:shooting_sports_analyst/logger.dart";
 import "package:shooting_sports_analyst/server/isolate/isolate_client.dart";
-import "package:shooting_sports_analyst/server/isolate/isolate_entrypoint.dart";
+import "package:shooting_sports_analyst/server/isolate/isolate_common.dart";
+import "package:shooting_sports_analyst/server/isolate/isolate_messages.dart";
 import "package:shooting_sports_analyst/server/isolate/isolate_server_helper.dart";
 import "package:shooting_sports_analyst/util.dart";
+
+final _log = SSALogger("IsolateMatchCache");
 
 /// A client for the isolate-based match cache, which connects to the
 /// server isolate to cache and look up matches.
 class IsolateMatchCacheClient implements MatchCache {
   static IsolateMatchCacheClient? _instance;
-  factory IsolateMatchCacheClient(SendPort managerSendPort) {
+  factory IsolateMatchCacheClient(IsolateManagerClient isolateManagerClient) {
     if(_instance == null) {
-      _instance = IsolateMatchCacheClient._internal(managerSendPort);
+      _instance = IsolateMatchCacheClient._internal(isolateManagerClient);
     }
     return _instance!;
   }
-  IsolateMatchCacheClient._internal(SendPort managerSendPort) {
+  IsolateMatchCacheClient._internal(this.isolateManagerClient) {
     if(IsolateCommon.isolateId == "unset") {
       throw Exception("IsolateCommon.isolateId is not set. Isolate must be started with IsolateCommon.setup() first in the isolate entrypoint.");
     }
-    isolateManagerClient = IsolateManagerClient(IsolateCommon.isolateId, managerSendPort);
     _init();
   }
 
   Future<void> _init() async {
     await isolateManagerClient.ready;
-    await isolateManagerClient.connect(isolateId: _IsolateMatchCacheServer.id);
+    await isolateManagerClient.connect(isolateId: IsolateMatchCacheServer.id);
     _readyCompleter.complete(true);
   }
 
   Future<bool> get clientReady => _readyCompleter.future;
   final Completer<bool> _readyCompleter = Completer();
 
-  late final IsolateManagerClient isolateManagerClient;
+  final IsolateManagerClient isolateManagerClient;
 
   @override
   Future<bool> ready() {
@@ -54,7 +57,7 @@ class IsolateMatchCacheClient implements MatchCache {
   @override
   Future<void> cache(ShootingMatch match) {
     return isolateManagerClient.sendCommand<_CacheCommand, _AckResponse>(
-      isolateId: _IsolateMatchCacheServer.id,
+      isolateId: IsolateMatchCacheServer.id,
       command: _CacheCommand(match: match)
     );
   }
@@ -62,7 +65,7 @@ class IsolateMatchCacheClient implements MatchCache {
   @override
   FutureOr<void> clear() {
     return isolateManagerClient.sendCommand<_ClearCommand, _AckResponse>(
-      isolateId: _IsolateMatchCacheServer.id,
+      isolateId: IsolateMatchCacheServer.id,
       command: _ClearCommand()
     );
   }
@@ -70,7 +73,7 @@ class IsolateMatchCacheClient implements MatchCache {
   @override
   Future<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match) async {
     var response = await isolateManagerClient.sendCommand<_GetByDbIdCommand, _IsolateMatchCacheServerResponse>(
-      isolateId: _IsolateMatchCacheServer.id,
+      isolateId: IsolateMatchCacheServer.id,
       command: _GetByDbIdCommand(id: match.id)
     );
 
@@ -92,7 +95,7 @@ class IsolateMatchCacheClient implements MatchCache {
   @override
   Future<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId) async {
     var response = await isolateManagerClient.sendCommand<_GetBySourceIdCommand, _IsolateMatchCacheServerResponse>(
-      isolateId: _IsolateMatchCacheServer.id,
+      isolateId: IsolateMatchCacheServer.id,
       command: _GetBySourceIdCommand(sourceId: sourceId)
     );
 
@@ -114,16 +117,24 @@ class IsolateMatchCacheClient implements MatchCache {
   @override
   FutureOr<void> remove(int id) {
     return isolateManagerClient.sendCommand<_RemoveCommand, _AckResponse>(
-      isolateId: _IsolateMatchCacheServer.id,
+      isolateId: IsolateMatchCacheServer.id,
       command: _RemoveCommand(id: id)
     );
+  }
+
+  static Future<IsolateMatchCacheClient> startOnCurrentIsolate(IsolateStartData startData, {bool existingIsolate = true}) async {
+    var managerClient = await IsolateCommon.setupClient(startData, existingIsolate: existingIsolate);
+    var client = IsolateMatchCacheClient(managerClient);
+    await client.clientReady;
+
+    return client;
   }
 }
 
 /// A server isolate that wraps a [HydratedMatchCache] and provides an isolate server interface for it.
 ///
 /// This allows the cache to be used by multiple worker isolates.
-class _IsolateMatchCacheServer {
+class IsolateMatchCacheServer {
   static const id = "match_cache";
   final ReceivePort receivePort;
   late final ServerIsolateHelper<_IsolateMatchCacheServerCommand, _IsolateMatchCacheServerResponse> serverHelper;
@@ -131,7 +142,7 @@ class _IsolateMatchCacheServer {
 
   final HydratedMatchCache cache = HydratedMatchCache();
 
-  _IsolateMatchCacheServer({
+  IsolateMatchCacheServer({
     required this.receivePort
   }) {
     serverHelper = ServerIsolateHelper(isolateId: id, commandHandler: _commandHandler);
@@ -154,9 +165,12 @@ class _IsolateMatchCacheServer {
       case _GetByDbIdCommand(id: var matchId):
         if(cache.contains(matchId)) {
           var result = cache.getById(matchId);
+          var match = result.unwrap();
+          _log.v("Cache hit, returning match: ${match.name}");
           return _MatchResponse(match: result.unwrap());
         }
         else {
+          _log.v("Cache miss, loading from database");
           var match = await db.getMatch(matchId);
           if(match == null) {
             return _ErrorResponse(message: "Match not found");
@@ -165,7 +179,10 @@ class _IsolateMatchCacheServer {
           if(hydrated.isErr()) {
             return _ErrorResponse(message: "Failed to hydrate match: ${hydrated.unwrapErr().message}");
           }
-          return _MatchResponse(match: hydrated.unwrap());
+          var hydratedMatch = hydrated.unwrap();
+          cache.cache(hydratedMatch);
+          _log.v("Cached match: ${hydratedMatch.name}");
+          return _MatchResponse(match: hydratedMatch);
         }
 
       case _GetBySourceIdCommand(sourceId: var sourceId):
@@ -177,6 +194,14 @@ class _IsolateMatchCacheServer {
           return _ErrorResponse(message: result.unwrapErr().message);
         }
     }
+  }
+
+  static Future<void> entrypoint(IsolateStartData startData) async {
+    IsolateCommon.setup(startData);
+    final matchCacheReceivePort = ReceivePort();
+    var server = IsolateMatchCacheServer(receivePort: matchCacheReceivePort);
+    await server.serverHelper.handleStartup(startData: startData);
+    await Future.delayed(Duration(days: 10000));
   }
 }
 

--- a/lib/data/cache/match/isolate_match_cache.dart
+++ b/lib/data/cache/match/isolate_match_cache.dart
@@ -1,0 +1,57 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import "dart:async";
+
+import "package:shooting_sports_analyst/data/cache/match/match_cache.dart";
+import "package:shooting_sports_analyst/data/database/schema/match.dart";
+import "package:shooting_sports_analyst/data/sport/match/match.dart";
+import "package:shooting_sports_analyst/util.dart";
+
+/// A client for the isolate-based match cache, which connects to the
+/// server isolate to cache and look up matches.
+class IsolateMatchCacheClient implements MatchCache {
+  static final IsolateMatchCacheClient _instance = IsolateMatchCacheClient._internal();
+  factory IsolateMatchCacheClient() => _instance;
+  IsolateMatchCacheClient._internal();
+
+  @override
+  FutureOr<bool> ready() {
+    // TODO: implement ready
+    throw UnimplementedError();
+  }
+
+  @override
+  FutureOr<void> cache(ShootingMatch match) {
+    // TODO: implement cache
+    throw UnimplementedError();
+  }
+
+  @override
+  FutureOr<void> clear() {
+    // TODO: implement clear
+    throw UnimplementedError();
+  }
+
+  @override
+  FutureOr<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match) {
+    // TODO: implement get
+    throw UnimplementedError();
+  }
+
+  @override
+  FutureOr<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId) {
+    // TODO: implement getBySourceId
+    throw UnimplementedError();
+  }
+
+  @override
+  FutureOr<void> remove(int id) {
+    // TODO: implement remove
+    throw UnimplementedError();
+  }
+}
+

--- a/lib/data/cache/match/isolate_match_cache.dart
+++ b/lib/data/cache/match/isolate_match_cache.dart
@@ -5,53 +5,259 @@
  */
 
 import "dart:async";
+import "dart:isolate";
 
 import "package:shooting_sports_analyst/data/cache/match/match_cache.dart";
+import "package:shooting_sports_analyst/data/database/analyst_database.dart";
+import "package:shooting_sports_analyst/data/database/match/hydrated_cache.dart";
 import "package:shooting_sports_analyst/data/database/schema/match.dart";
 import "package:shooting_sports_analyst/data/sport/match/match.dart";
+import "package:shooting_sports_analyst/server/isolate/isolate_client.dart";
+import "package:shooting_sports_analyst/server/isolate/isolate_entrypoint.dart";
+import "package:shooting_sports_analyst/server/isolate/isolate_server_helper.dart";
 import "package:shooting_sports_analyst/util.dart";
 
 /// A client for the isolate-based match cache, which connects to the
 /// server isolate to cache and look up matches.
 class IsolateMatchCacheClient implements MatchCache {
-  static final IsolateMatchCacheClient _instance = IsolateMatchCacheClient._internal();
-  factory IsolateMatchCacheClient() => _instance;
-  IsolateMatchCacheClient._internal();
+  static IsolateMatchCacheClient? _instance;
+  factory IsolateMatchCacheClient(SendPort managerSendPort) {
+    if(_instance == null) {
+      _instance = IsolateMatchCacheClient._internal(managerSendPort);
+    }
+    return _instance!;
+  }
+  IsolateMatchCacheClient._internal(SendPort managerSendPort) {
+    if(IsolateCommon.isolateId == "unset") {
+      throw Exception("IsolateCommon.isolateId is not set. Isolate must be started with IsolateCommon.setup() first in the isolate entrypoint.");
+    }
+    isolateManagerClient = IsolateManagerClient(IsolateCommon.isolateId, managerSendPort);
+    _init();
+  }
+
+  Future<void> _init() async {
+    await isolateManagerClient.ready;
+    await isolateManagerClient.connect(isolateId: _IsolateMatchCacheServer.id);
+    _readyCompleter.complete(true);
+  }
+
+  Future<bool> get clientReady => _readyCompleter.future;
+  final Completer<bool> _readyCompleter = Completer();
+
+  late final IsolateManagerClient isolateManagerClient;
 
   @override
-  FutureOr<bool> ready() {
-    // TODO: implement ready
-    throw UnimplementedError();
+  Future<bool> ready() {
+    return clientReady;
   }
 
   @override
-  FutureOr<void> cache(ShootingMatch match) {
-    // TODO: implement cache
-    throw UnimplementedError();
+  Future<void> cache(ShootingMatch match) {
+    return isolateManagerClient.sendCommand<_CacheCommand, _AckResponse>(
+      isolateId: _IsolateMatchCacheServer.id,
+      command: _CacheCommand(match: match)
+    );
   }
 
   @override
   FutureOr<void> clear() {
-    // TODO: implement clear
-    throw UnimplementedError();
+    return isolateManagerClient.sendCommand<_ClearCommand, _AckResponse>(
+      isolateId: _IsolateMatchCacheServer.id,
+      command: _ClearCommand()
+    );
   }
 
   @override
-  FutureOr<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match) {
-    // TODO: implement get
-    throw UnimplementedError();
+  Future<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match) async {
+    var response = await isolateManagerClient.sendCommand<_GetByDbIdCommand, _IsolateMatchCacheServerResponse>(
+      isolateId: _IsolateMatchCacheServer.id,
+      command: _GetByDbIdCommand(id: match.id)
+    );
+
+    if(response == null) {
+      return Result.err(StringError("No response from server isolate"));
+    }
+    var data = response.data;
+    if(data is _MatchResponse) {
+      return Result.ok(data.match);
+    }
+    else if(data is _ErrorResponse) {
+      return Result.err(StringError(data.message));
+    }
+    else {
+      return Result.err(StringError("Invalid response from server isolate: ${data.runtimeType}"));
+    }
   }
 
   @override
-  FutureOr<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId) {
-    // TODO: implement getBySourceId
-    throw UnimplementedError();
+  Future<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId) async {
+    var response = await isolateManagerClient.sendCommand<_GetBySourceIdCommand, _IsolateMatchCacheServerResponse>(
+      isolateId: _IsolateMatchCacheServer.id,
+      command: _GetBySourceIdCommand(sourceId: sourceId)
+    );
+
+    if(response == null) {
+      return Result.err(StringError("No response from server isolate"));
+    }
+    var data = response.data;
+    if(data is _MatchResponse) {
+      return Result.ok(data.match);
+    }
+    else if(data is _ErrorResponse) {
+      return Result.err(StringError(data.message));
+    }
+    else {
+      return Result.err(StringError("Invalid response from server isolate: ${data.runtimeType}"));
+    }
   }
 
   @override
   FutureOr<void> remove(int id) {
-    // TODO: implement remove
-    throw UnimplementedError();
+    return isolateManagerClient.sendCommand<_RemoveCommand, _AckResponse>(
+      isolateId: _IsolateMatchCacheServer.id,
+      command: _RemoveCommand(id: id)
+    );
   }
 }
 
+/// A server isolate that wraps a [HydratedMatchCache] and provides an isolate server interface for it.
+///
+/// This allows the cache to be used by multiple worker isolates.
+class _IsolateMatchCacheServer {
+  static const id = "match_cache";
+  final ReceivePort receivePort;
+  late final ServerIsolateHelper<_IsolateMatchCacheServerCommand, _IsolateMatchCacheServerResponse> serverHelper;
+  final db = AnalystDatabase();
+
+  final HydratedMatchCache cache = HydratedMatchCache();
+
+  _IsolateMatchCacheServer({
+    required this.receivePort
+  }) {
+    serverHelper = ServerIsolateHelper(isolateId: id, commandHandler: _commandHandler);
+  }
+
+  Future<_IsolateMatchCacheServerResponse> _commandHandler(_IsolateMatchCacheServerCommand command) async {
+    switch(command) {
+      case _CacheCommand(match: var match):
+        cache.cache(match);
+        return _AckResponse();
+
+      case _RemoveCommand(id: var id):
+        cache.remove(id);
+        return _AckResponse();
+
+      case _ClearCommand():
+        cache.clear();
+        return _AckResponse();
+
+      case _GetByDbIdCommand(id: var matchId):
+        if(cache.contains(matchId)) {
+          var result = cache.getById(matchId);
+          return _MatchResponse(match: result.unwrap());
+        }
+        else {
+          var match = await db.getMatch(matchId);
+          if(match == null) {
+            return _ErrorResponse(message: "Match not found");
+          }
+          var hydrated = await match.hydrate();
+          if(hydrated.isErr()) {
+            return _ErrorResponse(message: "Failed to hydrate match: ${hydrated.unwrapErr().message}");
+          }
+          return _MatchResponse(match: hydrated.unwrap());
+        }
+
+      case _GetBySourceIdCommand(sourceId: var sourceId):
+        var result = cache.getBySourceId(sourceId);
+        if(result.isOk()) {
+          return _MatchResponse(match: result.unwrap());
+        }
+        else {
+          return _ErrorResponse(message: result.unwrapErr().message);
+        }
+    }
+  }
+}
+
+/// A command from a client isolate to the match cache server isolate.
+sealed class _IsolateMatchCacheServerCommand {
+  const _IsolateMatchCacheServerCommand();
+}
+
+/// Cache a match, overwriting any existing match with the same database ID
+/// and source IDs.
+///
+/// Responds with [_AckResponse] if the command was received and processed,
+/// or [_ErrorResponse] if the command was invalid.
+class _CacheCommand extends _IsolateMatchCacheServerCommand {
+  final ShootingMatch match;
+
+  const _CacheCommand({required this.match});
+}
+
+/// Remove a match from the cache by its database ID.
+///
+/// Responds with [_AckResponse] if the command was received and processed,
+/// even if the match was not found in the cache.
+class _RemoveCommand extends _IsolateMatchCacheServerCommand {
+  final int id;
+
+  const _RemoveCommand({required this.id});
+}
+
+/// Clear the cache.
+///
+/// Responds with [_AckResponse] if the command was received and processed.
+class _ClearCommand extends _IsolateMatchCacheServerCommand {
+  const _ClearCommand();
+}
+
+/// Get a hydrated match from the cache by its database ID. Unlike the MatchCache interface,
+/// this takes a raw database ID rather than a [DbShootingMatch] object. The server isolate
+/// load the match from the database and hydrate it if it is not already in the cache.
+///
+/// Responds with [_MatchResponse] if the match could be found in
+/// the cache or was loaded from the database and cached. Responds with [_ErrorResponse]
+/// if the match was not found in the database.
+class _GetByDbIdCommand extends _IsolateMatchCacheServerCommand {
+  final int id;
+
+  const _GetByDbIdCommand({required this.id});
+}
+
+/// Get a hydrated match from the cache by a source ID.
+///
+/// Responds with [_MatchResponse] if the match was found in the cache
+/// or [_ErrorResponse] if the match was not found in the cache.
+///
+/// Note that getBySourceId does not attempt to load the match from the database if it is not found in the cache.
+class _GetBySourceIdCommand extends _IsolateMatchCacheServerCommand {
+  final String sourceId;
+
+  const _GetBySourceIdCommand({required this.sourceId});
+}
+
+/// A response from the match cache server isolate to a client isolate.
+sealed class _IsolateMatchCacheServerResponse {
+  const _IsolateMatchCacheServerResponse();
+}
+
+/// A hydrated match.
+class _MatchResponse extends _IsolateMatchCacheServerResponse {
+  final ShootingMatch match;
+
+  const _MatchResponse({required this.match});
+}
+
+/// A simple acknowledgement that the command was received and processed, without any associated data.
+class _AckResponse extends _IsolateMatchCacheServerResponse {
+  const _AckResponse();
+}
+
+/// An error message.
+class _ErrorResponse extends _IsolateMatchCacheServerResponse {
+  final String message;
+
+  const _ErrorResponse({required this.message});
+}

--- a/lib/data/cache/match/match_cache.dart
+++ b/lib/data/cache/match/match_cache.dart
@@ -4,6 +4,7 @@ import 'package:shooting_sports_analyst/data/cache/match/isolate_match_cache.dar
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/schema/match.dart';
 import 'package:shooting_sports_analyst/data/sport/match/match.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_common.dart';
 import 'package:shooting_sports_analyst/util.dart';
 
 /// A cache for matches. Use [MatchCache.instance] to get an instance
@@ -30,7 +31,10 @@ abstract interface class MatchCache {
   static MatchCache get instance {
     if(_instance == null) {
       if(serverMode) {
-        _instance = IsolateMatchCacheClient();
+        if(IsolateCommon.managerSendPort == null) {
+          throw Exception("IsolateCommon.managerSendPort is not set. Isolate must be started with IsolateCommon.setup() first in the isolate entrypoint.");
+        }
+        _instance = IsolateMatchCacheClient(IsolateCommon.managerSendPort!);
       }
       else {
         _instance = inMemoryInstance;

--- a/lib/data/cache/match/match_cache.dart
+++ b/lib/data/cache/match/match_cache.dart
@@ -4,8 +4,12 @@ import 'package:shooting_sports_analyst/data/cache/match/isolate_match_cache.dar
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/schema/match.dart';
 import 'package:shooting_sports_analyst/data/sport/match/match.dart';
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_common.dart';
 import 'package:shooting_sports_analyst/util.dart';
+
+final _log = SSALogger("MatchCache");
 
 /// A cache for matches. Use [MatchCache.instance] to get an instance
 /// appropriate for the current mode.
@@ -25,18 +29,26 @@ abstract interface class MatchCache {
   FutureOr<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match);
   FutureOr<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId);
 
-  static bool serverMode = false;
+  static setInstance(MatchCache instance) {
+    _instance = instance;
+    if(instance is HydratedMatchCache) {
+      _inMemoryInstance = instance;
+    }
+  }
+
   static MatchCache? _instance;
   static HydratedMatchCache? _inMemoryInstance;
   static MatchCache get instance {
+    var serverMode = FlutterOrNative.serverModeProvider.kServerMode;
     if(_instance == null) {
       if(serverMode) {
-        if(IsolateCommon.managerSendPort == null) {
-          throw Exception("IsolateCommon.managerSendPort is not set. Isolate must be started with IsolateCommon.setup() first in the isolate entrypoint.");
+        _log.i("Server mode: using isolate match cache");
+        if(_instance == null) {
+          throw Exception("MatchCache must be set before use in server mode.");
         }
-        _instance = IsolateMatchCacheClient(IsolateCommon.managerSendPort!);
       }
       else {
+        _log.i("Not server mode: using in-memory match cache");
         _instance = inMemoryInstance;
       }
     }

--- a/lib/data/cache/match/match_cache.dart
+++ b/lib/data/cache/match/match_cache.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:shooting_sports_analyst/data/cache/match/isolate_match_cache.dart';
+import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
+import 'package:shooting_sports_analyst/data/database/schema/match.dart';
+import 'package:shooting_sports_analyst/data/sport/match/match.dart';
+import 'package:shooting_sports_analyst/util.dart';
+
+/// A cache for matches. Use [MatchCache.instance] to get an instance
+/// appropriate for the current mode.
+///
+/// When [serverMode] is true, the cache will be an isolate-safe cache
+/// (using a server isolate to handle singleton storage) [IsolateMatchCacheClient]. When false,
+/// it will return a local in-memory cache [HydratedMatchCache].
+///
+/// In UI code, you can use [MatchCache.hydratedInstance] to always get a hydrated cache,
+/// which is fully synchronous and can be more readily used in UI code. In
+/// data-handling code, prefer to use [MatchCache.instance] for isolate safety.
+abstract interface class MatchCache {
+  FutureOr<bool> ready();
+  FutureOr<void> cache(ShootingMatch match);
+  FutureOr<void> remove(int id);
+  FutureOr<void> clear();
+  FutureOr<Result<ShootingMatch, ResultErr>> get(DbShootingMatch match);
+  FutureOr<Result<ShootingMatch, ResultErr>> getBySourceId(String sourceId);
+
+  static bool serverMode = false;
+  static MatchCache? _instance;
+  static HydratedMatchCache? _hydratedInstance;
+  static MatchCache get instance {
+    if(_instance == null) {
+      if(serverMode) {
+        _instance = IsolateMatchCacheClient();
+      }
+      else {
+        _instance = hydratedInstance;
+      }
+    }
+    return _instance!;
+  }
+
+  static HydratedMatchCache get hydratedInstance {
+    if(_hydratedInstance == null) {
+      _hydratedInstance = HydratedMatchCache();
+    }
+    return _hydratedInstance!;
+  }
+}

--- a/lib/data/cache/match/match_cache.dart
+++ b/lib/data/cache/match/match_cache.dart
@@ -13,7 +13,7 @@ import 'package:shooting_sports_analyst/util.dart';
 /// (using a server isolate to handle singleton storage) [IsolateMatchCacheClient]. When false,
 /// it will return a local in-memory cache [HydratedMatchCache].
 ///
-/// In UI code, you can use [MatchCache.hydratedInstance] to always get a hydrated cache,
+/// In UI code, you can use [MatchCache.inMemoryInstance] to always get a hydrated cache,
 /// which is fully synchronous and can be more readily used in UI code. In
 /// data-handling code, prefer to use [MatchCache.instance] for isolate safety.
 abstract interface class MatchCache {
@@ -26,23 +26,23 @@ abstract interface class MatchCache {
 
   static bool serverMode = false;
   static MatchCache? _instance;
-  static HydratedMatchCache? _hydratedInstance;
+  static HydratedMatchCache? _inMemoryInstance;
   static MatchCache get instance {
     if(_instance == null) {
       if(serverMode) {
         _instance = IsolateMatchCacheClient();
       }
       else {
-        _instance = hydratedInstance;
+        _instance = inMemoryInstance;
       }
     }
     return _instance!;
   }
 
-  static HydratedMatchCache get hydratedInstance {
-    if(_hydratedInstance == null) {
-      _hydratedInstance = HydratedMatchCache();
+  static HydratedMatchCache get inMemoryInstance {
+    if(_inMemoryInstance == null) {
+      _inMemoryInstance = HydratedMatchCache();
     }
-    return _hydratedInstance!;
+    return _inMemoryInstance!;
   }
 }

--- a/lib/data/database/analyst_database.dart
+++ b/lib/data/database/analyst_database.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:isar_community/isar.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/match_query_element.dart';
 import 'package:shooting_sports_analyst/data/database/schema/fantasy/fantasy_user.dart';
@@ -604,7 +605,7 @@ class AnalystDatabase {
 
     // For least confusion
     match.databaseId = dbMatch.id;
-    HydratedMatchCache().cache(match);
+    await MatchCache.instance.cache(match);
     return Result.ok(dbMatch);
   }
 
@@ -640,7 +641,10 @@ class AnalystDatabase {
 
     // For least confusion
     match.databaseId = dbMatch.id;
-    HydratedMatchCache().cache(match);
+
+    // This is unawaited async, but we probably won't immediately need
+    // the result again.
+    MatchCache.instance.cache(match);
     return Result.ok(dbMatch);
   }
 

--- a/lib/data/database/extensions/match_heat.dart
+++ b/lib/data/database/extensions/match_heat.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:data/stats.dart' show WeibullDistribution;
 import 'package:isar_community/isar.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/rating_project_database.dart';
@@ -78,7 +79,7 @@ extension MatchHeatDatabase on AnalystDatabase {
       _log.w("Match not found: ${ptr.name}");
       return null;
     }
-    var matchRes = await HydratedMatchCache().get(dbMatch);
+    var matchRes = await MatchCache.instance.get(dbMatch);
     if(matchRes.isErr()) {
       _log.w("Error hydrating match: ${matchRes.unwrapErr()}");
       return null;

--- a/lib/data/database/match/hydrated_cache.dart
+++ b/lib/data/database/match/hydrated_cache.dart
@@ -30,6 +30,8 @@ class HydratedMatchCache implements MatchCache {
     }
   }
 
+  bool contains(int id) => _cache.containsKey(id);
+
   @override
   void remove(int id) {
     _cache.remove(id);
@@ -51,6 +53,13 @@ class HydratedMatchCache implements MatchCache {
       cache(result.unwrap());
     }
     return result;
+  }
+
+  Result<ShootingMatch, ResultErr> getById(int id) {
+    if(_cache.containsKey(id)) {
+      return Result.ok(_cache[id]!);
+    }
+    return Result.err(StringError("id not found in cache"));
   }
 
   @override

--- a/lib/data/database/match/hydrated_cache.dart
+++ b/lib/data/database/match/hydrated_cache.dart
@@ -4,11 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import "package:shooting_sports_analyst/data/cache/match/match_cache.dart";
 import "package:shooting_sports_analyst/data/database/schema/match.dart";
 import "package:shooting_sports_analyst/data/sport/match/match.dart";
 import "package:shooting_sports_analyst/util.dart";
 
-class HydratedMatchCache {
+class HydratedMatchCache implements MatchCache {
   static final HydratedMatchCache _instance = HydratedMatchCache._internal();
   factory HydratedMatchCache() => _instance;
   HydratedMatchCache._internal();
@@ -16,6 +17,10 @@ class HydratedMatchCache {
   final Map<int, ShootingMatch> _cache = {};
   final Map<String, ShootingMatch> _sourceIdCache = {};
 
+  @override
+  bool ready() => true;
+
+  @override
   void cache(ShootingMatch match) {
     if(match.databaseId != null) {
       _cache[match.databaseId!] = match;
@@ -25,14 +30,17 @@ class HydratedMatchCache {
     }
   }
 
+  @override
   void remove(int id) {
     _cache.remove(id);
   }
 
+  @override
   void clear() {
     _cache.clear();
   }
 
+  @override
   Result<ShootingMatch, ResultErr> get(DbShootingMatch match) {
     if (_cache.containsKey(match.id)) {
       return Result.ok(_cache[match.id]!);
@@ -45,6 +53,7 @@ class HydratedMatchCache {
     return result;
   }
 
+  @override
   Result<ShootingMatch, ResultErr> getBySourceId(String sourceId) {
     if(_sourceIdCache.containsKey(sourceId)) {
       return Result.ok(_sourceIdCache[sourceId]!);

--- a/lib/data/database/match/hydrated_cache.dart
+++ b/lib/data/database/match/hydrated_cache.dart
@@ -46,7 +46,7 @@ class HydratedMatchCache implements MatchCache {
       return Result.ok(_cache[match.id]!);
     }
 
-    var result = match.hydrate();
+    var result = match.hydrateSync();
     if (result.isOk()) {
       cache(result.unwrap());
     }

--- a/lib/data/database/match/rating_project_database.dart
+++ b/lib/data/database/match/rating_project_database.dart
@@ -5,6 +5,7 @@
  */
 
 import 'package:isar_community/isar.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/migration_result.dart';
@@ -503,7 +504,7 @@ extension RatingProjectDatabase on AnalystDatabase {
               late DateTime matchStart;
               if(Timings.enabled) matchStart = DateTime.now();
               // If the hydrated match is cached, build a dummy match with the correct DB ID for the event.
-              var cacheResult = HydratedMatchCache().getBySourceId(event.matchId);
+              var cacheResult = await MatchCache.instance.getBySourceId(event.matchId);
               DbShootingMatch? match = null;
               if(cacheResult.isOk()) {
                 var m = cacheResult.unwrap();
@@ -557,7 +558,7 @@ extension RatingProjectDatabase on AnalystDatabase {
     // For more than 500 ratings, do 100 transactions total. For less than 50, just
     // call the sync version directly.
     if(ratingsList.length < 50) {
-      updateChangedRatingsSync(ratings, useCache: useCache, matches: matches);
+      await updateChangedRatingsSync(ratings, useCache: useCache, matches: matches);
       return;
     }
 
@@ -579,7 +580,7 @@ extension RatingProjectDatabase on AnalystDatabase {
         endIndex = ratingsList.length;
       }
       var batch = ratingsList.sublist(startIndex, endIndex);
-      updateChangedRatingsSync(batch, useCache: useCache, matches: matches);
+      await updateChangedRatingsSync(batch, useCache: useCache, matches: matches);
 
       totalProcessed = endIndex;
       if(onPersisted != null) {
@@ -599,10 +600,28 @@ extension RatingProjectDatabase on AnalystDatabase {
   /// for a hybrid sync-async operation that supports progress callbacks without the loss of speed of the fully async version.
   ///
   /// Takes and returns a map of match IDs to DbShootingMatch objects as an internal optimization.
-  Map<String, DbShootingMatch> updateChangedRatingsSync(Iterable<DbShooterRating> ratings, {bool useCache = true, Map<String, DbShootingMatch>? matches}) {
+  Future<Map<String, DbShootingMatch>> updateChangedRatingsSync(Iterable<DbShooterRating> ratings, {bool useCache = true, Map<String, DbShootingMatch>? matches}) async {
     late DateTime outerStart;
     if(Timings.enabled) outerStart = DateTime.now();
     matches ??= {};
+    late DateTime matchStart;
+    if(Timings.enabled) matchStart = DateTime.now();
+    for(var r in ratings) {
+      for(var event in r.newRatingEvents) {
+        if(!event.isPersisted) {
+          if(event.matchId.isNotEmpty && (!event.match.isLoaded || event.match.value == null)) {
+            if(Timings.enabled) matchStart = DateTime.now();
+            var cacheResult = await MatchCache.instance.getBySourceId(event.matchId);
+            var match = cacheResult.isOk() ? cacheResult.unwrap() : null;
+            if(match != null) {
+              matches[event.matchId] = DbShootingMatch.dbPlaceholder(match.databaseId!);
+            }
+          }
+        }
+      }
+    }
+    if(Timings.enabled) Timings().add(TimingType.getEventMatches, DateTime.now().difference(matchStart).inMicroseconds);
+
     isar.writeTxnSync(() {
       late DateTime start;
       for(var r in ratings) {
@@ -621,26 +640,14 @@ extension RatingProjectDatabase on AnalystDatabase {
             if(event.matchId.isNotEmpty && (!event.match.isLoaded || event.match.value == null)) {
               late DateTime matchStart;
               if(Timings.enabled) matchStart = DateTime.now();
-              // If the hydrated match is cached, build a dummy match with the correct DB ID for the event.
-              var cacheResult = HydratedMatchCache().getBySourceId(event.matchId);
-              DbShootingMatch? match = null;
-              if(cacheResult.isOk()) {
-                var m = cacheResult.unwrap();
-                if(m.databaseId != null) {
-                  DbShootingMatch placeholder = DbShootingMatch.dbPlaceholder(m.databaseId!);
-                  match = placeholder;
-                }
-              }
 
               // Otherwise, check our local cache.
-              if(match == null) {
-                match = matches![event.matchId];
-              }
+              var match = matches![event.matchId];
 
               // If it still isn't available, ask the DB.
               if(match == null) {
                 match = this.getMatchByAnySourceIdSync([event.matchId]);
-                matches![event.matchId] = match!;
+                matches[event.matchId] = match!;
               }
               event.match.value = match;
               if(Timings.enabled) Timings().add(TimingType.getEventMatches, DateTime.now().difference(matchStart).inMicroseconds);

--- a/lib/data/database/schema/fantasy/player.dart
+++ b/lib/data/database/schema/fantasy/player.dart
@@ -152,7 +152,7 @@ class FantasyPlayer with DbSportEntity {
     );
     Set<String> matchIds = events.map((e) => e.matchId).toSet();
     var matches = await db.getMatchesByAnySourceIds(matchIds.toList());
-    return matches.map((m) => m.hydrate(useCache: true).unwrap()).toList();
+    return matches.map((m) => m.hydrateSync(useCache: true).unwrap()).toList();
   }
 
   /// The teams that this player is on, across all leagues.

--- a/lib/data/database/schema/match.dart
+++ b/lib/data/database/schema/match.dart
@@ -7,6 +7,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:isar_community/isar.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/schema/ratings.dart';
@@ -293,9 +294,26 @@ class DbShootingMatch with DbSportEntity implements SourceIdsProvider {
 
   }
 
-  Result<ShootingMatch, ResultErr> hydrate({bool useCache = false}) {
+  /// Hydrate this match into a [ShootingMatch].
+  ///
+  /// If [useCache] is true, this match will be loaded from the cache if it is available.
+  /// This method should be preferred over [hydrateSync], as this method will use the sync
+  /// cache if available and fall back to the async cache if not.
+  Future<Result<ShootingMatch, ResultErr>> hydrate({bool useCache = false}) async {
     if(useCache) {
-      var cached = HydratedMatchCache().get(this);
+      var cached = await MatchCache.instance.get(this);
+      if(cached.isOk()) return Result.ok(cached.unwrap());
+    }
+    return hydrateSync(useCache: false);
+  }
+
+  /// Hydrate this match into a [ShootingMatch].
+  ///
+  /// This method will only use the in-memory cache, and should be avoided in multi-isolate
+  /// contexts (and data handling code called from multi-isolate contexts).
+  Result<ShootingMatch, ResultErr> hydrateSync({bool useCache = false}) {
+    if(useCache) {
+      var cached = MatchCache.inMemoryInstance.get(this);
       if(cached.isOk()) return Result.ok(cached.unwrap());
     }
 

--- a/lib/data/prediction_game/prediction_game_manager.dart
+++ b/lib/data/prediction_game/prediction_game_manager.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:isar_community/isar.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/extensions/prediction_game.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
@@ -229,7 +230,7 @@ class PredictionGameManager {
   ///
   /// Any matches provided in [matches] will be used to calculate scores. Other matches will be
   /// loaded from the database as needed.
-  Map<DbWager, WagerScores> getAllRelevantScores(List<DbWager> wagers, {Map<DbWager, ShootingMatch>? matches}) {
+  Future<Map<DbWager, WagerScores>> getAllRelevantScores(List<DbWager> wagers, {Map<DbWager, ShootingMatch>? matches}) async {
     /// First load all matches we need, if not provided.
     if(matches == null) {
       matches = {};
@@ -239,7 +240,7 @@ class PredictionGameManager {
       if(match == null) {
         var dbMatch = wager.matchPrep.value?.futureMatch.value?.dbMatch.value;
         if(dbMatch != null) {
-          var matchRes = HydratedMatchCache().get(dbMatch);
+          var matchRes = await MatchCache.instance.get(dbMatch);
           if(matchRes.isOk()) {
             match = matchRes.unwrap();
           }

--- a/lib/data/prediction_game/prediction_game_manager.dart
+++ b/lib/data/prediction_game/prediction_game_manager.dart
@@ -346,7 +346,7 @@ class PredictionGameManager {
   /// for both the match result and the result within the prediction set.
   ///
   /// If [match] is provided, it will be used to calculate the scores
-  WagerScores getRelevantScores(DbWager wager, {ShootingMatch? match}) {
+  Future<WagerScores> getRelevantScores(DbWager wager, {ShootingMatch? match}) async {
     var scores = WagerScores(wager: wager);
     ShootingMatch? actualMatch;
     var dbMatch = wager.matchPrep.value?.futureMatch.value?.dbMatch.value;
@@ -354,7 +354,7 @@ class PredictionGameManager {
       return scores;
     }
     if(match == null) {
-      var matchRes = HydratedMatchCache().get(dbMatch);
+      var matchRes = await MatchCache.instance.get(dbMatch);
       if(matchRes.isOk()) {
         actualMatch = matchRes.unwrap();
       }

--- a/lib/data/ranking/model/rating_change.dart
+++ b/lib/data/ranking/model/rating_change.dart
@@ -5,6 +5,7 @@
  */
 
 import 'package:collection/collection.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/schema/match.dart';
 import 'package:shooting_sports_analyst/data/database/schema/ratings/db_rating_event.dart';
@@ -68,14 +69,14 @@ abstract class RatingEvent implements IRatingEvent, IConnectivityEvent {
   ShootingMatch? _cachedMatch;
   ShootingMatch get match {
     if(_cachedMatch == null) {
-      var res = HydratedMatchCache().getBySourceId(wrappedEvent.matchId);
+      var res = MatchCache.inMemoryInstance.getBySourceId(wrappedEvent.matchId);
       if(res.isOk()) {
         _cachedMatch = res.unwrap();
       }
     }
     if(_cachedMatch == null) {
       wrappedEvent.match.loadSync();
-      var res = wrappedEvent.match.value!.hydrate(useCache: true);
+      var res = wrappedEvent.match.value!.hydrateSync(useCache: true);
       _cachedMatch = res.unwrap();
     }
 

--- a/lib/data/ranking/prediction/odds/wager.dart
+++ b/lib/data/ranking/prediction/odds/wager.dart
@@ -152,6 +152,14 @@ class Parlay implements IWager {
     // Find the maximum place we need to consider
     var placeLegs = legs.where((leg) => leg.prediction is PlacePrediction).toList();
     var placePredictions = placeLegs.map((leg) => leg.prediction as PlacePrediction).toList();
+
+
+    if(placePredictions.length < 2) {
+      // Only parlays with more than one place prediction can be impossible to
+      // satisfy.
+      return true;
+    }
+
     var maxPlace = placePredictions.map((p) => p.worstPlace).reduce(max);
 
     // Try to assign each prediction to a valid place

--- a/lib/data/ranking/project_loader.dart
+++ b/lib/data/ranking/project_loader.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:fuzzywuzzy/fuzzywuzzy.dart' as fuzzywuzzy;
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/rating_project_database.dart';
@@ -183,7 +184,7 @@ class RatingProjectLoader {
     wallStart = DateTime.now();
     this.skipDeduplication = skipDeduplication;
 
-    HydratedMatchCache().clear();
+    await MatchCache.instance.clear();
     db.clearLoadedShooterRatingCache();
     timings.reset();
 

--- a/lib/data/ranking/project_loader.dart
+++ b/lib/data/ranking/project_loader.dart
@@ -341,7 +341,7 @@ class RatingProjectLoader {
         ));
       }
 
-      var matchRes = dbMatch.unwrap().hydrate(useCache: true);
+      var matchRes = dbMatch.unwrap().hydrateSync(useCache: true);
       if(matchRes.isErr()) {
         var err = matchRes.unwrapErr();
         return Result.err(MatchLoadFailureError(

--- a/lib/data/ranking/project_rollback.dart
+++ b/lib/data/ranking/project_rollback.dart
@@ -5,6 +5,7 @@
  */
 
 import 'package:collection/collection.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/rating_project_database.dart';
@@ -129,7 +130,7 @@ class RatingProjectRollback {
       for(var ptr in matches) {
         var dbMatch = db.getMatchByAnySourceIdSync(ptr.sourceIds);
         if (dbMatch != null) {
-          var hydrated = HydratedMatchCache().get(dbMatch);
+          var hydrated = await MatchCache.instance.get(dbMatch);
           if(hydrated.isOk()) {
             matchesRemoved.add(hydrated.unwrap());
           }

--- a/lib/data/source/practiscore_report_ui.dart
+++ b/lib/data/source/practiscore_report_ui.dart
@@ -60,7 +60,7 @@ class PractiscoreReportUI extends SourceUI {
                       onError(MatchSourceError.databaseError);
                     }
                     else {
-                      var hydratedMatch = res.unwrap().hydrate();
+                      var hydratedMatch = await res.unwrap().hydrate();
                       if(hydratedMatch.isErr()) {
                         onError(MatchSourceError.databaseError);
                       }

--- a/lib/data/source/ssa_source/ssa_server_source.dart
+++ b/lib/data/source/ssa_source/ssa_server_source.dart
@@ -238,7 +238,7 @@ class SSAServerMatchSource extends MatchSource<ServerMatchType, SSAServerMatchFe
         if(localCopy == null) {
           return Result.err(MatchSourceError.notModified);
         }
-        var hydrateRes = localCopy.hydrate();
+        var hydrateRes = await localCopy.hydrate();
         if(hydrateRes.isErr()) {
           return Result.err(GeneralError(StringError("Failed to hydrate local copy: ${hydrateRes.unwrapErr().message}")));
         }

--- a/lib/data/source/ssa_source/ssa_server_source_ui.dart
+++ b/lib/data/source/ssa_source/ssa_server_source_ui.dart
@@ -56,7 +56,7 @@ class SSAServerSourceUI extends SourceUI {
                         );
                         if(matches == null) return;
                         for(var match in matches) {
-                          var hydratedRes = match.hydrate();
+                          var hydratedRes = await match.hydrate();
                           if(hydratedRes.isErr()) {
                             onError(FormatError(hydratedRes.unwrapErr()));
                             continue;
@@ -106,7 +106,7 @@ class SSAServerSourceUI extends SourceUI {
                           if (res.isErr()) {
                             onError(MatchSourceError.databaseError);
                           } else {
-                            var hydratedMatch = res.unwrap().hydrate();
+                            var hydratedMatch = await res.unwrap().hydrate();
                             if (hydratedMatch.isErr()) {
                               onError(MatchSourceError.databaseError);
                             } else {
@@ -388,7 +388,7 @@ class _SSASearchResultsState extends State<SSASearchResults> {
         return;
       }
 
-      var hydratedMatch = res.unwrap().hydrate();
+      var hydratedMatch = await res.unwrap().hydrate();
       if (hydratedMatch.isErr()) {
         setState(() {
           downloadStates[result.matchId] = DownloadState.error;

--- a/lib/data/sport/scoring/scoring.dart
+++ b/lib/data/sport/scoring/scoring.dart
@@ -152,8 +152,6 @@ class RelativeMatchScore extends RelativeScore {
   String toString() {
     return "RelativeMatchScore($place, $ratio)";
   }
-
-  RelativeMatchScore? firstWhereOrNull(bool Function(dynamic element) param0) {}
 }
 
 class RelativeStageScore extends RelativeScore {

--- a/lib/flutter_native_providers.dart
+++ b/lib/flutter_native_providers.dart
@@ -9,9 +9,15 @@ import 'package:shooting_sports_analyst/config/serialized_config.dart';
 /// This class provides access to a variety of interfaces that are different
 /// between Flutter code and Dart-only code. By implementing and filling
 class FlutterOrNative {
+  static ServerModeProvider? _serverModeProvider;
   static DebugModeProvider? _debugModeProvider;
   static ConfigProvider? _configProvider;
   static MachineFingerprintProvider? _machineFingerprintProvider;
+
+  static ServerModeProvider get serverModeProvider => _serverModeProvider!;
+  static set serverModeProvider(ServerModeProvider provider) {
+    _serverModeProvider = provider;
+  }
 
   static DebugModeProvider get debugModeProvider => _debugModeProvider!;
   static set debugModeProvider(DebugModeProvider provider) {
@@ -30,6 +36,10 @@ class FlutterOrNative {
   static bool check() {
     return _debugModeProvider != null && _configProvider != null && _machineFingerprintProvider != null;
   }
+}
+
+abstract interface class ServerModeProvider {
+  bool get kServerMode;
 }
 
 abstract interface class DebugModeProvider {

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -205,15 +205,17 @@ class _SSAFileOutput {
 class _SSALogOutput extends LogOutput {
   final bool console;
   final bool file;
-  final bool sendPort;
 
-  _SSAFileOutput fileOutput = _SSAFileOutput();
+  _SSAFileOutput? fileOutput;
   _SSASendPortOutput? sendPortOutput;
 
   late Future<bool> launchFuture;
 
-  _SSALogOutput({this.console = true, this.file = false, this.sendPort = false}) {
-    if(file) launchFuture = fileOutput.launchFuture;
+  _SSALogOutput({this.console = true, this.file = false}) {
+    if(file && SSALogger.fileOutput) {
+      fileOutput = _SSAFileOutput();
+      launchFuture = fileOutput!.launchFuture;
+    }
     else launchFuture = Future.value(true);
   }
 
@@ -222,7 +224,7 @@ class _SSALogOutput extends LogOutput {
     await launchFuture;
 
     if(this.console && SSALogger.consoleOutput) event.lines.forEach((element) { print(element); });
-    if(this.file && SSALogger.fileOutput) fileOutput.write(event.lines.join("\n"));
+    if(this.file && SSALogger.fileOutput) fileOutput!.write(event.lines.join("\n"));
     if(SSALogger.sendPortOutput) SSALogger._sendPortOutput!.send(event);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,11 +64,14 @@ class GlobalData {
 
 GlobalData globals = GlobalData();
 
-class FlutterDebugProvider implements DebugModeProvider {
+class FlutterDebugProvider implements DebugModeProvider, ServerModeProvider {
   bool get kDebugMode => foundation.kDebugMode;
 
   @override
   bool get kReleaseMode => foundation.kReleaseMode;
+
+  @override
+  bool get kServerMode => false;
 }
 
 class FlutterConfigProvider implements ConfigProvider {
@@ -146,7 +149,9 @@ class FlutterSecureStorageProvider implements SecureStorageProvider {
 }
 
 void main() async {
-  FlutterOrNative.debugModeProvider = FlutterDebugProvider();
+  var provider = FlutterDebugProvider();
+  FlutterOrNative.debugModeProvider = provider;
+  FlutterOrNative.serverModeProvider = provider;
   FlutterOrNative.machineFingerprintProvider = FlutterMachineFingerprinter();
   // dumpRatings();
 

--- a/lib/route/configure_ratings.dart
+++ b/lib/route/configure_ratings.dart
@@ -757,8 +757,13 @@ class _ConfigureRatingsPageState extends State<ConfigureRatingsPage> {
                                               ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Failed to load match from database.")));
                                               return;
                                             }
+                                            var canonicalMatch = await dbMatch.unwrap().hydrate();
+                                            if(canonicalMatch.isErr()) {
+                                              ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Failed to hydrate match.")));
+                                              return;
+                                            }
                                             Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-                                              return ResultPage(canonicalMatch: dbMatch.unwrap().hydrate().unwrap(), allowWhatIf: false);
+                                              return ResultPage(canonicalMatch: canonicalMatch.unwrap(), allowWhatIf: false);
                                             }));
                                           },
                                           child: Text(

--- a/lib/route/match_heat_page.dart
+++ b/lib/route/match_heat_page.dart
@@ -499,7 +499,7 @@ class _MatchHeatGraphPageState extends State<MatchHeatGraphPage> {
               var pointer = _matchHeat.keys.toList()[index];
               var dbMatch = await AnalystDatabase().getMatchByAnySourceId(pointer.sourceIds);
               if(dbMatch != null) {
-                var matchRes = await dbMatch.hydrate(useCache: true);
+                var matchRes = await dbMatch.hydrateSync(useCache: true);
                 if(matchRes.isOk()) {
                   var match = matchRes.unwrap();
                   Navigator.push(context, MaterialPageRoute(builder: (context) => ResultPage(

--- a/lib/route/view_ratings.dart
+++ b/lib/route/view_ratings.dart
@@ -173,7 +173,12 @@ class _RatingsViewPageState extends State<RatingsViewPage> with TickerProviderSt
     _settings = await widget.dataSource.getSettings().unwrap();
     activeTabs = await widget.dataSource.getGroups().unwrap();
     activeTabs.sort((a, b) => a.sortOrder.compareTo(b.sortOrder));
-    _selectedMatch = (await widget.dataSource.getLatestMatch()).unwrap().hydrate().unwrap();
+    var _latestMatch = await widget.dataSource.getLatestMatch();
+    if(_latestMatch.isErr()) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Failed to load latest match.")));
+      return;
+    }
+    _selectedMatch = (await _latestMatch.unwrap().hydrate()).unwrap();
     _sport = await widget.dataSource.getSport().unwrap();
     _tabController = TabController(
         length: activeTabs.length,
@@ -666,7 +671,7 @@ class _RatingsViewPageState extends State<RatingsViewPage> with TickerProviderSt
         if(match != null) {
           var dbMatch = await match.getDbMatch(AnalystDatabase()).unwrap();
           Navigator.of(context).push(MaterialPageRoute(builder: (context) {
-            return ResultPage(canonicalMatch: dbMatch.hydrate(useCache: true).unwrap(), allowWhatIf: false, ratings: widget.dataSource);
+            return ResultPage(canonicalMatch: dbMatch.hydrateSync(useCache: true).unwrap(), allowWhatIf: false, ratings: widget.dataSource);
           }));
         }
         break;

--- a/lib/server/fantasy/cli/calculate_annual_stats.dart
+++ b/lib/server/fantasy/cli/calculate_annual_stats.dart
@@ -143,7 +143,7 @@ Future<(Map<DbShooterRating, DbFantasyStats>?, String?)> _calculateFantasyStatsB
   if(dbMatch == null) {
     return (null, "No match found for ${matchPointer.name} at ${matchPointer.sourceIds.firstOrNull}");
   }
-  var hydratedMatch = dbMatch.hydrate(useCache: true);
+  var hydratedMatch = dbMatch.hydrateSync(useCache: true);
   if(hydratedMatch.isErr()) {
     return (null, "Error hydrating match: ${hydratedMatch.unwrapErr()}");
   }

--- a/lib/server/fantasy/league_service.dart
+++ b/lib/server/fantasy/league_service.dart
@@ -6,6 +6,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:shelf_plus/shelf_plus.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/match/rating_project_database.dart';
@@ -67,7 +68,7 @@ class LeagueService {
         continue;
       }
       matchIds.add(dbMatch.sourceIds.first);
-      final matchRes = HydratedMatchCache().get(dbMatch);
+      final matchRes = await MatchCache.instance.get(dbMatch);
       if(matchRes.isErr()) {
         return Response.internalServerError(body: 'Failed to get match');
       }

--- a/lib/server/isolate/example/hello_world_isolate_client.dart
+++ b/lib/server/isolate/example/hello_world_isolate_client.dart
@@ -33,14 +33,26 @@ class HelloWorldIsolateClient {
 
   /// The entrypoint for the client isolate, which handles initial setup
   /// (setting up common isolate variables in [IsolateCommon]) and connecting to the server isolate.
+  ///
+  /// Pass this method to Isolate.spawn to run it on a new isolate, or call [startOnCurrentIsolate] to create a
+  /// HelloWorldIsolateClient on the existing isolate.
   static Future<void> entrypoint(IsolateStartData startData) async {
-    IsolateCommon.setup(startData);
-    var managerClient = IsolateManagerClient(IsolateCommon.isolateId, IsolateCommon.managerSendPort!);
-    await managerClient.ready;
+    var client = await startOnCurrentIsolate(startData, existingIsolate: false);
+
+    // Real client code would probably wait on a webserver or some other long-running task, and
+    // use the returned client to interact with the server isolate.
+    await Future.delayed(Duration(days: 10000));
+  }
+
+  /// Create a HelloWorldIsolateClient on the current isolate.
+  static Future<HelloWorldIsolateClient> startOnCurrentIsolate(IsolateStartData startData, {bool existingIsolate = true}) async {
+    var managerClient = await IsolateCommon.setupClient(startData, existingIsolate: existingIsolate);
     var client = HelloWorldIsolateClient(IsolateCommon.isolateId, managerClient);
     await client.connect();
     _log.i("Client connected to server isolate");
+    startData.initPort.send(StartupCompleteResponse(sourceIsolateId: IsolateCommon.isolateId));
     var helloWorld = await client.getHelloWorld();
     _log.i("Hello world: $helloWorld");
+    return client;
   }
 }

--- a/lib/server/isolate/example/hello_world_isolate_client.dart
+++ b/lib/server/isolate/example/hello_world_isolate_client.dart
@@ -1,0 +1,44 @@
+
+
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_server.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_client.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+import 'package:shooting_sports_analyst/server/providers.dart';
+
+final _log = SSALogger("HelloWorldIsolateClient");
+
+class HelloWorldIsolateClient {
+  final String isolateId;
+  final IsolateManagerClient _isolateManagerClient;
+
+  HelloWorldIsolateClient(this.isolateId, this._isolateManagerClient);
+
+  Future<void> connect() async {
+    await _isolateManagerClient.connect(isolateId: HelloWorldServer.id);
+  }
+
+  Future<String> getHelloWorld() async {
+    var response = await _isolateManagerClient.sendCommand<HelloWorldServerCommand, HelloWorldServerResponse>(
+      isolateId: HelloWorldServer.id,
+      command: HelloWorldServerCommand()
+    );
+    if(response == null) {
+      throw Exception("No response from server isolate");
+    }
+    return response.data.data;
+  }
+
+  static Future<void> entrypoint(IsolateStartData startData) async {
+    FlutterOrNative.debugModeProvider = ServerDebugProvider();
+    SSALogger.setupSendPort(startData.logPort, isolateName: "hello_client");
+    var managerClient = IsolateManagerClient("hello_client", startData.managerPort!);
+    await managerClient.ready;
+    var client = HelloWorldIsolateClient("hello_client", managerClient);
+    await client.connect();
+    _log.i("Client connected to server isolate");
+    var helloWorld = await client.getHelloWorld();
+    _log.i("Hello world: $helloWorld");
+  }
+}

--- a/lib/server/isolate/example/hello_world_isolate_client.dart
+++ b/lib/server/isolate/example/hello_world_isolate_client.dart
@@ -4,6 +4,7 @@ import 'package:shooting_sports_analyst/flutter_native_providers.dart';
 import 'package:shooting_sports_analyst/logger.dart';
 import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_server.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_client.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_common.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
 import 'package:shooting_sports_analyst/server/providers.dart';
 
@@ -30,12 +31,13 @@ class HelloWorldIsolateClient {
     return response.data.data;
   }
 
+  /// The entrypoint for the client isolate, which handles initial setup
+  /// (setting up common isolate variables in [IsolateCommon]) and connecting to the server isolate.
   static Future<void> entrypoint(IsolateStartData startData) async {
-    FlutterOrNative.debugModeProvider = ServerDebugProvider();
-    SSALogger.setupSendPort(startData.logPort, isolateName: "hello_client");
-    var managerClient = IsolateManagerClient("hello_client", startData.managerPort!);
+    IsolateCommon.setup(startData);
+    var managerClient = IsolateManagerClient(IsolateCommon.isolateId, IsolateCommon.managerSendPort!);
     await managerClient.ready;
-    var client = HelloWorldIsolateClient("hello_client", managerClient);
+    var client = HelloWorldIsolateClient(IsolateCommon.isolateId, managerClient);
     await client.connect();
     _log.i("Client connected to server isolate");
     var helloWorld = await client.getHelloWorld();

--- a/lib/server/isolate/example/hello_world_isolate_example.dart
+++ b/lib/server/isolate/example/hello_world_isolate_example.dart
@@ -45,7 +45,7 @@ void main() async {
 
   var managerIsolate = await Isolate.spawn(
     IsolateManagerServer.entrypoint,
-    IsolateStartData(logPort: loggerSendPort, initPort: initIsolateSendPort, managerPort: null),
+    IsolateStartData(isolateId: IsolateManagerServer.id, logPort: loggerSendPort, initPort: initIsolateSendPort, managerPort: null),
   );
   _log.i("Manager isolate spawned");
   var managerIsolateSendPort = await managerIsolateSendPortCompleter.future;
@@ -53,16 +53,18 @@ void main() async {
 
   // Set up the final init data for non-manager isolates.
   final initData = IsolateStartData(
+    isolateId: "",
     logPort: loggerSendPort,
     initPort: initIsolateSendPort,
     managerPort: managerIsolateSendPort,
   );
 
   // Spawn the server isolate. Its helper will register with the manager isolate.
-  var helloWorldServerIsolate = await Isolate.spawn(HelloWorldServer.entrypoint, initData);
+  var helloWorldServerIsolate = await Isolate.spawn(HelloWorldServer.entrypoint, initData.copyWithId(HelloWorldServer.id));
 
-  // Spawn the client isolate. It will use its isolate's IsolateManagerClient to connect to the server isolate.
-  var helloWorldClientIsolate = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData);
+  // Spawn the client isolates. They will use their own isolate's IsolateManagerClient to connect to the server isolate.
+  var helloWorldClientIsolate1 = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData.copyWithId("hello_client1"));
+  var helloWorldClientIsolate2 = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData.copyWithId("hello_client2"));
 
   _log.i("Server and client isolates spawned");
 }

--- a/lib/server/isolate/example/hello_world_isolate_example.dart
+++ b/lib/server/isolate/example/hello_world_isolate_example.dart
@@ -1,0 +1,68 @@
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_client.dart';
+import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_server.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_manager.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+import 'package:shooting_sports_analyst/server/providers.dart';
+
+final _log = SSALogger("HelloWorldIsolateExample");
+
+void main() async {
+  FlutterOrNative.debugModeProvider = ServerDebugProvider();
+  // Create the ports for the init isolate and the logger isolate.
+  var initIsolateReceivePort = ReceivePort();
+  var initIsolateSendPort = initIsolateReceivePort.sendPort;
+
+  var loggerReceivePort = ReceivePort();
+  var loggerSendPort = loggerReceivePort.sendPort;
+
+  // Other isolates should use [SSALogger.setupSendPort] to send logs to the logger isolate.
+  SSALogger.handleReceivePort(loggerReceivePort);
+  _log.i("Logger setup complete");
+
+  // Create the manager isolate and get its send port.
+  final Completer<SendPort> managerIsolateSendPortCompleter = Completer();
+  final Function(dynamic) initReceivePortHandler = (message) {
+    _log.v("Init isolate received message: ${message.runtimeType}");
+    if(message is IsolateConnectionResponse) {
+      managerIsolateSendPortCompleter.complete(message.sendPort);
+    }
+    else {
+      _log.e("Init isolate received unexpected message: ${message.runtimeType}");
+      if(message is IsolateMessage) {
+        _log.e("IsolateMessage: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+      }
+      return;
+    }
+  };
+  _log.i("Init isolate receive port listener set up");
+  initIsolateReceivePort.listen(initReceivePortHandler);
+
+  var managerIsolate = await Isolate.spawn(
+    IsolateManagerServer.entrypoint,
+    IsolateStartData(logPort: loggerSendPort, initPort: initIsolateSendPort, managerPort: null),
+  );
+  _log.i("Manager isolate spawned");
+  var managerIsolateSendPort = await managerIsolateSendPortCompleter.future;
+  _log.i("Manager isolate send port received");
+
+  // Set up the final init data for non-manager isolates.
+  final initData = IsolateStartData(
+    logPort: loggerSendPort,
+    initPort: initIsolateSendPort,
+    managerPort: managerIsolateSendPort,
+  );
+
+  // Spawn the server isolate. Its helper will register with the manager isolate.
+  var helloWorldServerIsolate = await Isolate.spawn(HelloWorldServer.entrypoint, initData);
+
+  // Spawn the client isolate. It will use its isolate's IsolateManagerClient to connect to the server isolate.
+  var helloWorldClientIsolate = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData);
+
+  _log.i("Server and client isolates spawned");
+}

--- a/lib/server/isolate/example/hello_world_isolate_example.dart
+++ b/lib/server/isolate/example/hello_world_isolate_example.dart
@@ -6,6 +6,7 @@ import 'package:shooting_sports_analyst/flutter_native_providers.dart';
 import 'package:shooting_sports_analyst/logger.dart';
 import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_client.dart';
 import 'package:shooting_sports_analyst/server/isolate/example/hello_world_isolate_server.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_common.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_manager.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
 import 'package:shooting_sports_analyst/server/providers.dart';
@@ -13,7 +14,10 @@ import 'package:shooting_sports_analyst/server/providers.dart';
 final _log = SSALogger("HelloWorldIsolateExample");
 
 void main() async {
-  FlutterOrNative.debugModeProvider = ServerDebugProvider();
+  var provider = ServerDebugProvider();
+  FlutterOrNative.debugModeProvider = provider;
+  FlutterOrNative.serverModeProvider = provider;
+
   // Create the ports for the init isolate and the logger isolate.
   var initIsolateReceivePort = ReceivePort();
   var initIsolateSendPort = initIsolateReceivePort.sendPort;
@@ -25,37 +29,20 @@ void main() async {
   SSALogger.handleReceivePort(loggerReceivePort);
   _log.i("Logger setup complete");
 
-  // Create the manager isolate and get its send port.
-  final Completer<SendPort> managerIsolateSendPortCompleter = Completer();
-  final Function(dynamic) initReceivePortHandler = (message) {
-    _log.v("Init isolate received message: ${message.runtimeType}");
-    if(message is IsolateConnectionResponse) {
-      managerIsolateSendPortCompleter.complete(message.sendPort);
-    }
-    else {
-      _log.e("Init isolate received unexpected message: ${message.runtimeType}");
-      if(message is IsolateMessage) {
-        _log.e("IsolateMessage: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
-      }
-      return;
-    }
-  };
-  _log.i("Init isolate receive port listener set up");
-  initIsolateReceivePort.listen(initReceivePortHandler);
+  // Start the manager isolate and get its send port.
+  var managerIsolateSendPort = await IsolateCommon.startManagerIsolate(loggerSendPort: loggerSendPort, initIsolateReceivePort: initIsolateReceivePort);
 
-  var managerIsolate = await Isolate.spawn(
-    IsolateManagerServer.entrypoint,
-    IsolateStartData(isolateId: IsolateManagerServer.id, logPort: loggerSendPort, initPort: initIsolateSendPort, managerPort: null),
-  );
-  _log.i("Manager isolate spawned");
-  var managerIsolateSendPort = await managerIsolateSendPortCompleter.future;
-  _log.i("Manager isolate send port received");
-
+  var startupReceivePort = ReceivePort();
+  startupReceivePort.listen((message) {
+    if(message is StartupCompleteResponse) {
+      _log.i("Startup complete for isolate ${message.sourceIsolateId}");
+    }
+  });
   // Set up the final init data for non-manager isolates.
   final initData = IsolateStartData(
     isolateId: "",
     logPort: loggerSendPort,
-    initPort: initIsolateSendPort,
+    initPort: startupReceivePort.sendPort,
     managerPort: managerIsolateSendPort,
   );
 
@@ -66,5 +53,7 @@ void main() async {
   var helloWorldClientIsolate1 = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData.copyWithId("hello_client1"));
   var helloWorldClientIsolate2 = await Isolate.spawn(HelloWorldIsolateClient.entrypoint, initData.copyWithId("hello_client2"));
 
+  var mainIsolateData = initData.copyWithId("main");
+  var mainIsolateClient = await HelloWorldIsolateClient.startOnCurrentIsolate(mainIsolateData, existingIsolate: true);
   _log.i("Server and client isolates spawned");
 }

--- a/lib/server/isolate/example/hello_world_isolate_server.dart
+++ b/lib/server/isolate/example/hello_world_isolate_server.dart
@@ -1,0 +1,36 @@
+
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_server_helper.dart';
+import 'package:shooting_sports_analyst/server/providers.dart';
+
+class HelloWorldServer {
+  static const id = "hello_server";
+  late final ServerIsolateHelper<HelloWorldServerCommand, HelloWorldServerResponse> helper;
+
+  HelloWorldServer() {
+    helper = ServerIsolateHelper<HelloWorldServerCommand, HelloWorldServerResponse>(isolateId: id, commandHandler: commandHandler);
+  }
+
+  Future<HelloWorldServerResponse> commandHandler(HelloWorldServerCommand command) async {
+    return HelloWorldServerResponse(data: "Hello, world!");
+  }
+
+  static Future<void> entrypoint(IsolateStartData startData) async {
+    FlutterOrNative.debugModeProvider = ServerDebugProvider();
+    SSALogger.setupSendPort(startData.logPort, isolateName: id);
+    var serverIsolate = HelloWorldServer();
+    serverIsolate.helper.handleStartup(startData.managerPort!);
+    await Future.delayed(Duration(days: 10000));
+  }
+}
+
+class HelloWorldServerCommand {
+  HelloWorldServerCommand();
+}
+
+class HelloWorldServerResponse {
+  final String data;
+  HelloWorldServerResponse({required this.data});
+}

--- a/lib/server/isolate/example/hello_world_isolate_server.dart
+++ b/lib/server/isolate/example/hello_world_isolate_server.dart
@@ -1,9 +1,7 @@
 
-import 'package:shooting_sports_analyst/flutter_native_providers.dart';
-import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_common.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_server_helper.dart';
-import 'package:shooting_sports_analyst/server/providers.dart';
 
 class HelloWorldServer {
   static const id = "hello_server";
@@ -18,10 +16,9 @@ class HelloWorldServer {
   }
 
   static Future<void> entrypoint(IsolateStartData startData) async {
-    FlutterOrNative.debugModeProvider = ServerDebugProvider();
-    SSALogger.setupSendPort(startData.logPort, isolateName: id);
+    IsolateCommon.setup(startData);
     var serverIsolate = HelloWorldServer();
-    serverIsolate.helper.handleStartup(startData.managerPort!);
+    serverIsolate.helper.handleStartup(IsolateCommon.managerSendPort!);
     await Future.delayed(Duration(days: 10000));
   }
 }

--- a/lib/server/isolate/example/hello_world_isolate_server.dart
+++ b/lib/server/isolate/example/hello_world_isolate_server.dart
@@ -18,7 +18,7 @@ class HelloWorldServer {
   static Future<void> entrypoint(IsolateStartData startData) async {
     IsolateCommon.setup(startData);
     var serverIsolate = HelloWorldServer();
-    serverIsolate.helper.handleStartup(IsolateCommon.managerSendPort!);
+    serverIsolate.helper.handleStartup(startData: startData);
     await Future.delayed(Duration(days: 10000));
   }
 }

--- a/lib/server/isolate/isolate_client.dart
+++ b/lib/server/isolate/isolate_client.dart
@@ -27,6 +27,9 @@ final _log = SSALogger("IsolateManagerClient");
 /// 4. Use [sendCommand] to send commands directly to the server isolate using the
 ///    stored send port. The server isolate processes the command and returns a
 ///    [ServerResponse] containing the result.
+///
+/// [C] is the command type.
+/// [R] is the response type.
 class IsolateManagerClient {
   /// The isolate ID of the current isolate.
   final String thisIsolateId;

--- a/lib/server/isolate/isolate_client.dart
+++ b/lib/server/isolate/isolate_client.dart
@@ -7,29 +7,26 @@ import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
 
 final _log = SSALogger("IsolateManagerClient");
 
-/// IsolateManagerClient is a convenience function for inter-isolate communication
-/// along server isolate/client isolate patterns. It provides a single point of
-/// entry for client isolates (e.g. webserver isolates) to register with server
-/// isolates (e.g. the isolate match cache), exchanging send/receive ports to
-/// establish communications without the main isolate having to pass in ports
-/// for every single server isolate.
+/// IsolateManagerClient is a singleton helper class for client isolates to communicate
+/// with server isolates through the IsolateManagerServer. It provides a single point of
+/// entry for client isolates (e.g. webserver isolates) to connect to server isolates
+/// (e.g. the isolate match cache), exchanging send/receive ports to establish direct
+/// communication without the main isolate having to pass in ports for every server isolate.
 ///
-/// Server isolates managed by the IsolateManager should handle messages of type
-/// [IsolateConnectionRequest] and respond with messages of type [IsolateConnectionResponse].
+/// The client automatically registers with the IsolateManagerServer upon construction.
+/// Server isolates should use [ServerIsolateHelper] to handle connection requests and
+/// commands from client isolates.
 ///
-/// IsolateManager should generally be used to implement type-safe client isolate
-/// classes that communicate with their respective server isolates. The process
-/// goes like this:
+/// Typical usage in a client isolate:
 ///
-/// 1. ClientIsolate gets the IsolateManager in its internal code.
-/// 2. ClientIsolate uses [IsolateManagerClient.ready] to verify that the manager
-/// is ready to accept commands.
-/// 3. ClientIsolate uses [IsolateManagerClient.connect] to connect to the server isolate
-/// or isolate(s).
-/// 4. ClientIsolate uses [IsolateManagerClient.sendCommand] to send commands to the server
-/// isolate(s), and receives ServerResponse objects containing any desired data.
-///
-/// Server isolates
+/// 1. Create an instance of IsolateManagerClient with the isolate ID and manager send port.
+/// 2. Wait for [ready] to complete to ensure registration with the manager is finished.
+/// 3. Call [connect] with a server isolate ID to establish a connection. The manager
+///    will forward the connection request to the server isolate, which responds with
+///    its receive port. The client stores this port for direct communication.
+/// 4. Use [sendCommand] to send commands directly to the server isolate using the
+///    stored send port. The server isolate processes the command and returns a
+///    [ServerResponse] containing the result.
 class IsolateManagerClient {
   /// The isolate ID of the current isolate.
   final String thisIsolateId;
@@ -77,8 +74,13 @@ class IsolateManagerClient {
     return response;
   }
 
-  /// Handle messages from IsolateManagerServer, which will
-  /// always be of type [IsolateConnectionResponse] or [IsolateRegistrationResponse].
+  /// Handle messages received on the client's receive port.
+  ///
+  /// Processes messages from both the IsolateManagerServer (registration and connection
+  /// responses) and from server isolates (command responses). Messages are:
+  /// - [IsolateRegistrationResponse]: Confirms registration with the manager
+  /// - [IsolateConnectionResponse]: Contains the server isolate's receive port after connection
+  /// - [ServerResponse]: Contains the result of a command sent to a server isolate
   Future<void> _listen(dynamic message) async {
     if(message is! IsolateMessage) {
       throw Exception("Invalid message type: ${message.runtimeType}");
@@ -106,9 +108,16 @@ class IsolateManagerClient {
 
   /// Connect to a server isolate.
   ///
-  /// [isolateId] specifies the isolate to connect to.
+  /// Sends an [IsolateConnectionRequest] to the IsolateManagerServer, which forwards
+  /// it to the target server isolate. The server isolate responds with an
+  /// [IsolateConnectionResponse] containing its receive port, which is stored for
+  /// future direct communication. If a connection to this server isolate already
+  /// exists, the cached send port is returned immediately.
   ///
-  /// The returned [SendPort] can be used to send messages to the server isolate.
+  /// [isolateId] specifies the server isolate to connect to.
+  ///
+  /// Returns a [SendPort] that can be used to send messages directly to the server
+  /// isolate's receive port.
   Future<SendPort> connect({
     required String isolateId,
   }) async {

--- a/lib/server/isolate/isolate_client.dart
+++ b/lib/server/isolate/isolate_client.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_manager.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+
+final _log = SSALogger("IsolateManagerClient");
+
+/// IsolateManagerClient is a convenience function for inter-isolate communication
+/// along server isolate/client isolate patterns. It provides a single point of
+/// entry for client isolates (e.g. webserver isolates) to register with server
+/// isolates (e.g. the isolate match cache), exchanging send/receive ports to
+/// establish communications without the main isolate having to pass in ports
+/// for every single server isolate.
+///
+/// Server isolates managed by the IsolateManager should handle messages of type
+/// [IsolateConnectionRequest] and respond with messages of type [IsolateConnectionResponse].
+///
+/// IsolateManager should generally be used to implement type-safe client isolate
+/// classes that communicate with their respective server isolates. The process
+/// goes like this:
+///
+/// 1. ClientIsolate gets the IsolateManager in its internal code.
+/// 2. ClientIsolate uses [IsolateManagerClient.ready] to verify that the manager
+/// is ready to accept commands.
+/// 3. ClientIsolate uses [IsolateManagerClient.connect] to connect to the server isolate
+/// or isolate(s).
+/// 4. ClientIsolate uses [IsolateManagerClient.sendCommand] to send commands to the server
+/// isolate(s), and receives ServerResponse objects containing any desired data.
+///
+/// Server isolates
+class IsolateManagerClient {
+  /// The isolate ID of the current isolate.
+  final String thisIsolateId;
+  /// The send port to the manager isolate.
+  final SendPort _managerSendPort;
+  /// The receive port from all isolates.
+  late final ReceivePort _serverReceivePort;
+
+  /// A map of isolate IDs to send ports used to send messages to those isolate IDs.
+  final Map<String, SendPort> _serverSendPorts = {};
+
+  Future<bool> get ready => _readyCompleter.future;
+  Completer<bool> _readyCompleter = Completer();
+  bool _registered = false;
+  bool get _commandInProgress => _commandCompleter != null;
+  Completer<ServerResponse?>? _commandCompleter;
+
+  static IsolateManagerClient? _instance;
+  factory IsolateManagerClient(String isolateId, SendPort managerSendPort) {
+    if(_instance == null) {
+      _instance = IsolateManagerClient._(isolateId, managerSendPort);
+    }
+    return _instance!;
+  }
+
+  IsolateManagerClient._(this.thisIsolateId, this._managerSendPort) {
+    _serverReceivePort = ReceivePort();
+    _serverReceivePort.listen(_listen);
+    _registerWithServer();
+  }
+
+  Future<ServerResponse?> _registerWithServer() async {
+    if(_commandInProgress) {
+      throw Exception("A command is already in progress");
+    }
+    _log.i("Client isolate $thisIsolateId registering with isolate manager server");
+    _commandCompleter = Completer();
+    _managerSendPort.send(IsolateRegistrationRequest(
+      sourceIsolateId: thisIsolateId,
+      destinationIsolateId: IsolateManagerServer.id,
+      sendPort: _serverReceivePort.sendPort)
+    );
+    var response = await _commandCompleter!.future;
+    _readyCompleter.complete(true);
+    return response;
+  }
+
+  /// Handle messages from IsolateManagerServer, which will
+  /// always be of type [IsolateConnectionResponse] or [IsolateRegistrationResponse].
+  Future<void> _listen(dynamic message) async {
+    if(message is! IsolateMessage) {
+      throw Exception("Invalid message type: ${message.runtimeType}");
+    }
+    if(message is IsolateRegistrationResponse) {
+      _registered = true;
+      _log.i("Client isolate $thisIsolateId registered with manager isolate");
+      _commandCompleter!.complete(null);
+    }
+    else if(message is IsolateConnectionResponse) {
+      _serverSendPorts[message.sourceIsolateId] = message.sendPort;
+      _log.i("Connected to server isolate ${message.sourceIsolateId}");
+      _commandCompleter!.complete(null);
+    }
+    else if(message is ServerResponse) {
+      _commandCompleter!.complete(message);
+    }
+    else {
+      _log.w("Received unexpected message from server isolate: ${message.runtimeType}");
+      _commandCompleter!.complete();
+    }
+
+    _commandCompleter = null;
+  }
+
+  /// Connect to a server isolate.
+  ///
+  /// [isolateId] specifies the isolate to connect to.
+  ///
+  /// The returned [SendPort] can be used to send messages to the server isolate.
+  Future<SendPort> connect({
+    required String isolateId,
+  }) async {
+    if(!_registered) {
+      throw Exception("Isolate not registered with IsolateManagerServer");
+    }
+    if(_commandInProgress) {
+      throw Exception("A command is already in progress");
+    }
+    if(_serverSendPorts.containsKey(isolateId)) {
+      _log.i("Reusing existing connection to server isolate $isolateId");
+      return _serverSendPorts[isolateId]!;
+    }
+    _log.i("Client isolate $thisIsolateId connecting to server isolate $isolateId");
+    _commandCompleter = Completer();
+    _managerSendPort.send(IsolateConnectionRequest(
+      sourceIsolateId: thisIsolateId,
+      destinationIsolateId: isolateId,
+      sendPort: _serverReceivePort.sendPort)
+    );
+    await _commandCompleter!.future;
+    return _serverSendPorts[isolateId]!;
+  }
+
+  /// Send a command to a server isolate.
+  ///
+  /// [isolateId] specifies the isolate to send the command to.
+  /// [command] is the command to send.
+  ///
+  /// The returned [ServerResponse] contains the response from the server isolate. Each server
+  /// isolate will define client command types [C] and server response types [R].
+  Future<ServerResponse<R>?> sendCommand<C, R>({
+    required String isolateId,
+    required C command,
+  }) async {
+    if(!_registered) {
+      throw Exception("Isolate not registered with IsolateManagerServer");
+    }
+    if(_commandInProgress) {
+      throw Exception("A command is already in progress");
+    }
+    if(!_serverSendPorts.containsKey(isolateId)) {
+      throw Exception("Server isolate $isolateId not found");
+    }
+
+    _commandCompleter = Completer();
+    _serverSendPorts[isolateId]!.send(ClientCommand(
+      sourceIsolateId: thisIsolateId,
+      destinationIsolateId: isolateId,
+      data: command)
+    );
+    var response = await _commandCompleter!.future;
+    if(response == null) {
+      throw Exception("No response from server isolate $isolateId");
+    }
+    return response as ServerResponse<R>;
+  }
+}

--- a/lib/server/isolate/isolate_client.dart
+++ b/lib/server/isolate/isolate_client.dart
@@ -159,8 +159,9 @@ class IsolateManagerClient {
     if(!_registered) {
       throw Exception("Isolate not registered with IsolateManagerServer");
     }
-    if(_commandInProgress) {
-      throw Exception("A command is already in progress");
+    while(_commandInProgress) {
+      // Wait for the current command to complete
+      await _commandCompleter!.future;
     }
     if(!_serverSendPorts.containsKey(isolateId)) {
       throw Exception("Server isolate $isolateId not found");

--- a/lib/server/isolate/isolate_common.dart
+++ b/lib/server/isolate/isolate_common.dart
@@ -1,0 +1,18 @@
+import 'dart:isolate';
+
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+import 'package:shooting_sports_analyst/server/providers.dart';
+
+class IsolateCommon {
+  static String isolateId = "unset";
+  static SendPort? managerSendPort;
+
+  static void setup(IsolateStartData startData) {
+    FlutterOrNative.debugModeProvider = ServerDebugProvider();
+    SSALogger.setupSendPort(startData.logPort, isolateName: startData.isolateId);
+    managerSendPort = startData.managerPort;
+    isolateId = startData.isolateId;
+  }
+}

--- a/lib/server/isolate/isolate_common.dart
+++ b/lib/server/isolate/isolate_common.dart
@@ -1,18 +1,72 @@
+import 'dart:async';
 import 'dart:isolate';
 
 import 'package:shooting_sports_analyst/flutter_native_providers.dart';
 import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_client.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_manager.dart';
 import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
 import 'package:shooting_sports_analyst/server/providers.dart';
+
+final _log = SSALogger("IsolateCommon");
 
 class IsolateCommon {
   static String isolateId = "unset";
   static SendPort? managerSendPort;
+  static IsolateManagerClient? managerClient;
 
-  static void setup(IsolateStartData startData) {
-    FlutterOrNative.debugModeProvider = ServerDebugProvider();
-    SSALogger.setupSendPort(startData.logPort, isolateName: startData.isolateId);
+  static void setup(IsolateStartData startData, {bool existingIsolate = false}) {
+    if(!existingIsolate) {
+      FlutterOrNative.debugModeProvider = ServerDebugProvider();
+      SSALogger.setupSendPort(startData.logPort, isolateName: startData.isolateId);
+    }
     managerSendPort = startData.managerPort;
     isolateId = startData.isolateId;
+  }
+
+  static Future<IsolateManagerClient> setupClient(IsolateStartData startData, {bool existingIsolate = false}) async {
+    setup(startData, existingIsolate: existingIsolate);
+    managerClient = IsolateManagerClient(isolateId, managerSendPort!);
+    await managerClient!.ready;
+    return managerClient!;
+  }
+
+  static Future<SendPort> startManagerIsolate({
+    required SendPort loggerSendPort,
+    required ReceivePort initIsolateReceivePort,
+  }) async {
+    final Completer<SendPort> managerIsolateSendPortCompleter = Completer();
+    final Function(dynamic) initReceivePortHandler = (message) {
+      _log.v("Init isolate received message: ${message.runtimeType}");
+      if(message is IsolateConnectionResponse) {
+        managerIsolateSendPortCompleter.complete(message.sendPort);
+      }
+      else {
+        _log.e("Init isolate received unexpected message: ${message.runtimeType}");
+        if(message is IsolateMessage) {
+          _log.e("IsolateMessage: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+        }
+        return;
+      }
+    };
+    _log.i("Init isolate receive port listener set up");
+    initIsolateReceivePort.listen(initReceivePortHandler);
+
+    var managerIsolate = await Isolate.spawn(
+      IsolateManagerServer.entrypoint,
+      IsolateStartData(
+        isolateId: IsolateManagerServer.id,
+        logPort: loggerSendPort,
+        initPort: initIsolateReceivePort.sendPort,
+        managerPort: null,
+      ),
+    );
+    _log.i("Manager isolate spawned");
+    var managerIsolateSendPort = await managerIsolateSendPortCompleter.future;
+    _log.i("Manager isolate send port received");
+
+    initIsolateReceivePort.close();
+    return managerIsolateSendPort;
+
   }
 }

--- a/lib/server/isolate/isolate_manager.dart
+++ b/lib/server/isolate/isolate_manager.dart
@@ -15,8 +15,18 @@ import 'package:shooting_sports_analyst/server/providers.dart';
 final _log = SSALogger("IsolateManager");
 
 
-/// IsolateManagerServer is a special server isolate that forwards [IsolateConnectionRequest]s
-/// to the appropriate server isolate and returns their [IsolateConnectionResponse]s.
+/// IsolateManagerServer is a central registry isolate that manages communication between
+/// client and server isolates. It maintains a registry of all registered isolates (both
+/// clients and servers) and their send ports.
+///
+/// When a client isolate wants to connect to a server isolate:
+/// 1. The client sends an [IsolateConnectionRequest] to the manager, containing a send port that sends to the client's receive port.
+/// 2. The manager forwards the request to the target server isolate.
+/// 3. The server isolate responds with an [IsolateConnectionResponse] containing a send port that sends to the server's receive port.
+/// 4. The manager forwards the response back to the client isolate.
+///
+/// After this exchange, the client and server isolates can communicate directly without
+/// going through the manager. The manager only facilitates the initial connection setup.
 class IsolateManagerServer {
   static const id = "isolate_manager";
 
@@ -78,19 +88,6 @@ class IsolateManagerServer {
         throw Exception("Isolate ${message.destinationIsolateId} not registered");
       }
     }
-  }
-
-  /// Register a server isolate with the IsolateManagerServer.
-  ///
-  /// [sendPort] is the port that the server isolate should use to send back to
-  /// this isolate.
-  Future<void> register(String isolateId, SendPort sendPort) async {
-    _sendPorts[isolateId] = sendPort;
-    sendPort.send(IsolateConnectionRequest(
-      sourceIsolateId: id,
-      destinationIsolateId: isolateId,
-      sendPort: sendPort,
-    ));
   }
 
   static Future<void> entrypoint(IsolateStartData startData) async {

--- a/lib/server/isolate/isolate_manager.dart
+++ b/lib/server/isolate/isolate_manager.dart
@@ -1,0 +1,107 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:shooting_sports_analyst/flutter_native_providers.dart';
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+import 'package:shooting_sports_analyst/server/providers.dart';
+
+final _log = SSALogger("IsolateManager");
+
+
+/// IsolateManagerServer is a special server isolate that forwards [IsolateConnectionRequest]s
+/// to the appropriate server isolate and returns their [IsolateConnectionResponse]s.
+class IsolateManagerServer {
+  static const id = "isolate_manager";
+
+  /// A map of isolate IDs to send ports used to send messages to those isolate IDs.
+  final Map<String, SendPort> _sendPorts = {};
+  final ReceivePort _receivePort = ReceivePort();
+
+  static IsolateManagerServer? _instance;
+  factory IsolateManagerServer() {
+    if(_instance == null) {
+      _instance = IsolateManagerServer._();
+    }
+    return _instance!;
+  }
+  IsolateManagerServer._() {
+    _receivePort.listen(_listen);
+  }
+
+  void _listen(dynamic message) {
+    _log.v("Manager isolate received message: ${message.runtimeType} ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+    if(message is! IsolateMessage) {
+      throw Exception("Invalid message type: ${message.runtimeType}");
+    }
+    else if(message is IsolateRegistrationRequest) {
+      if(_sendPorts.containsKey(message.sourceIsolateId)) {
+        throw Exception("Isolate ${message.sourceIsolateId} already registered");
+      }
+
+      // Save the client's send port.
+      _sendPorts[message.sourceIsolateId] = message.sendPort;
+      _sendPorts[message.sourceIsolateId]!.send(IsolateRegistrationResponse(
+        sourceIsolateId: id,
+        destinationIsolateId: message.sourceIsolateId,
+        sendPort: _receivePort.sendPort,
+      ));
+    }
+    else if(message is IsolateConnectionRequest) {
+      if(!_sendPorts.containsKey(message.sourceIsolateId)) {
+        throw Exception("Isolate ${message.sourceIsolateId} not registered");
+      }
+      // Forward the connection request to the server isolate.
+      _sendPorts[message.destinationIsolateId]!.send(IsolateConnectionRequest(
+        sourceIsolateId: message.sourceIsolateId,
+        destinationIsolateId: message.destinationIsolateId,
+        sendPort: _sendPorts[message.sourceIsolateId]!,
+      ));
+    }
+    else if(message is IsolateConnectionResponse) {
+      if(message.destinationIsolateId == id) {
+        // If the response is for us, it's a response from a server isolate to the message sent in
+        // register().
+        _sendPorts[message.sourceIsolateId] = message.sendPort;
+      }
+      else if(_sendPorts.containsKey(message.destinationIsolateId)) {
+        // Otherwise it's a response from a server isolate to a client isolate.
+        _sendPorts[message.destinationIsolateId]!.send(message);
+      }
+      else {
+        throw Exception("Isolate ${message.destinationIsolateId} not registered");
+      }
+    }
+  }
+
+  /// Register a server isolate with the IsolateManagerServer.
+  ///
+  /// [sendPort] is the port that the server isolate should use to send back to
+  /// this isolate.
+  Future<void> register(String isolateId, SendPort sendPort) async {
+    _sendPorts[isolateId] = sendPort;
+    sendPort.send(IsolateConnectionRequest(
+      sourceIsolateId: id,
+      destinationIsolateId: isolateId,
+      sendPort: sendPort,
+    ));
+  }
+
+  static Future<void> entrypoint(IsolateStartData startData) async {
+    FlutterOrNative.debugModeProvider = ServerDebugProvider();
+    SSALogger.setupSendPort(startData.logPort, isolateName: id);
+    var managerIsolate = IsolateManagerServer();
+    startData.initPort.send(IsolateConnectionResponse(
+      sourceIsolateId: id,
+      destinationIsolateId: "init",
+      sendPort: managerIsolate._receivePort.sendPort,
+    ));
+    await Future.delayed(Duration(days: 10000));
+  }
+}

--- a/lib/server/isolate/isolate_messages.dart
+++ b/lib/server/isolate/isolate_messages.dart
@@ -1,0 +1,100 @@
+
+import 'dart:isolate';
+
+sealed class IsolateMessage{
+  String get sourceIsolateId;
+  String get destinationIsolateId;
+}
+
+sealed class ClientRequest extends IsolateMessage{}
+sealed class ClientResponse extends IsolateMessage{}
+
+/// A request to register an isolate with the IsolateManagerServer, either a server or client.
+///
+/// [sourceIsolateId] is the isolate's ID.
+/// [sendPort] is the port that connects to the isolate's receive port.
+class IsolateRegistrationRequest extends ClientRequest {
+  /// The isolate ID of the source isolate of this message.
+  final String sourceIsolateId;
+  /// The isolate ID of the destination isolate of this message.
+  /// This should always be the manager isolate's ID.
+  final String destinationIsolateId;
+  /// The send port that connects to the isolate's receive port.
+  final SendPort sendPort;
+
+  IsolateRegistrationRequest({required this.sourceIsolateId, required this.destinationIsolateId, required this.sendPort});
+}
+
+/// A response to a [IsolateRegistrationRequest].
+///
+/// As isolates registering must receive the server's send port on registration, this
+/// response is just a confirmation.
+class IsolateRegistrationResponse extends ClientResponse {
+  /// The isolate ID of the registered client.
+  final String sourceIsolateId;
+  /// The isolate ID of the destination isolate.
+  final String destinationIsolateId;
+  /// The send port that connects to the manager isolate's receive port.
+  final SendPort sendPort;
+
+  IsolateRegistrationResponse({required this.sourceIsolateId, required this.destinationIsolateId, required this.sendPort});
+}
+
+/// A request to connect to a server isolate.
+///
+/// [sourceIsolateId] specifies the isolate to connect to.
+/// [sendPort] is the port used by the server isolate to send messages to the client isolate.
+class IsolateConnectionRequest extends ClientRequest {
+  final String sourceIsolateId;
+  final String destinationIsolateId;
+  final SendPort sendPort;
+
+  IsolateConnectionRequest({required this.sourceIsolateId, required this.destinationIsolateId, required this.sendPort});
+}
+
+/// A response to a [IsolateConnectionRequest].
+///
+/// [sendPort] is the port used by the client isolate to send messages to the server isolate.
+class IsolateConnectionResponse extends ClientResponse {
+  final String sourceIsolateId;
+  final String destinationIsolateId;
+  final SendPort sendPort;
+
+  IsolateConnectionResponse({required this.sourceIsolateId, required this.destinationIsolateId, required this.sendPort});
+}
+
+/// A command from a client isolate to a server isolate.
+///
+/// [sourceIsolateId] is the ID of the client isolate that sent the command.
+/// [data] is the data of the command.
+class ClientCommand<T> extends ClientRequest {
+  final String sourceIsolateId;
+  final String destinationIsolateId;
+  final T data;
+
+  ClientCommand({required this.sourceIsolateId, required this.destinationIsolateId, required this.data});
+}
+
+/// A response from a server isolate to a client isolate.
+///
+/// [sourceIsolateId] is the ID of the server isolate that sent the response.
+/// [data] is the data of the response.
+class ServerResponse<T> extends ClientResponse {
+  final String sourceIsolateId;
+  final String destinationIsolateId;
+  final T data;
+
+  ServerResponse({required this.sourceIsolateId, required this.destinationIsolateId, required this.data});
+}
+
+/// A convenience container for passing initial data to a server isolate.
+class IsolateStartData {
+  /// The send port to the logger isolate, for use in [SSALogger.setupSendPort].
+  final SendPort logPort;
+  /// The send port to the init isolate, for use in [ServerIsolateHelper.handleStartup].
+  final SendPort initPort;
+  /// The send port to the manager isolate, for use in [IsolateManagerServer.register].
+  final SendPort? managerPort;
+
+  IsolateStartData({required this.logPort, required this.initPort, this.managerPort});
+}

--- a/lib/server/isolate/isolate_messages.dart
+++ b/lib/server/isolate/isolate_messages.dart
@@ -87,14 +87,22 @@ class ServerResponse<T> extends ClientResponse {
   ServerResponse({required this.sourceIsolateId, required this.destinationIsolateId, required this.data});
 }
 
-/// A convenience container for passing initial data to a server isolate.
+/// A convenience container for passing initial data to a managed isolate.
 class IsolateStartData {
+  /// The isolate ID of the isolate.
+  final String isolateId;
   /// The send port to the logger isolate, for use in [SSALogger.setupSendPort].
   final SendPort logPort;
   /// The send port to the init isolate, for use in [ServerIsolateHelper.handleStartup].
   final SendPort initPort;
   /// The send port to the manager isolate, for use in [IsolateManagerServer.register].
+  ///
+  /// Not needed when starting the manager isolate, but required for all other isolates.
   final SendPort? managerPort;
 
-  IsolateStartData({required this.logPort, required this.initPort, this.managerPort});
+  IsolateStartData({required this.isolateId, required this.logPort, required this.initPort, this.managerPort});
+
+  IsolateStartData copyWithId(String newIsolateId) {
+    return IsolateStartData(isolateId: newIsolateId, logPort: logPort, initPort: initPort, managerPort: managerPort);
+  }
 }

--- a/lib/server/isolate/isolate_messages.dart
+++ b/lib/server/isolate/isolate_messages.dart
@@ -9,6 +9,16 @@ sealed class IsolateMessage{
 sealed class ClientRequest extends IsolateMessage{}
 sealed class ClientResponse extends IsolateMessage{}
 
+/// A message from an isolate to the init isolate, indicating that the new isolate
+/// has completed its startup process.
+class StartupCompleteResponse extends ClientResponse {
+  /// The isolate ID of the source isolate of this message.
+  final String sourceIsolateId;
+  final String destinationIsolateId = "init";
+
+  StartupCompleteResponse({required this.sourceIsolateId});
+}
+
 /// A request to register an isolate with the IsolateManagerServer, either a server or client.
 ///
 /// [sourceIsolateId] is the isolate's ID.

--- a/lib/server/isolate/isolate_server_helper.dart
+++ b/lib/server/isolate/isolate_server_helper.dart
@@ -10,21 +10,28 @@ final _log = SSALogger("ServerIsolateHelper");
 
 typedef ServerCommandHandler<C, R> = Future<R> Function(C command);
 
-/// A helper for server isolates that handles communication with client isolates,
-/// including the IsolateManagerServer, and handles converting server isolate-specific
-/// data types to and from the generic [IsolateMessage] types.
+/// A helper for server isolates that handles communication with client isolates
+/// through the IsolateManagerServer. It manages registration with the manager,
+/// handles connection requests from client isolates, and processes client commands.
 ///
 /// [C] is the client command data type for this server isolate.
-/// [R] is the server response datatype for this server isolate.
+/// [R] is the server response data type for this server isolate.
 ///
-/// To use:
-/// 1. Spawn your server isolate, passing in a send port that sends to the init receive port.
-/// 2. Create an instance of ServerIsolateHelper for your server isolate, and call [handleStartup]
-/// with the send port from the init isolate.
-/// 3. In the init isolate, call [IsolateManagerServer.register] with the send port from the server isolate.
-/// 4. [commandHandler] will be called when a command is received from a client isolate.
-/// 5. [commandHandler] should return a [ServerResponse] object.
-/// 6. The [ServerResponse] object will be sent back to the client isolate that sent the command.
+/// Typical usage in a server isolate:
+///
+/// 1. Spawn the server isolate, passing [IsolateStartData] that includes the manager send port.
+/// 2. Create an instance of ServerIsolateHelper with the isolate ID and a command handler function.
+/// 3. Call [handleStartup] with the manager send port from [IsolateStartData.managerPort].
+///    This sends an [IsolateRegistrationRequest] to the manager. Wait for [registered] to complete.
+/// 4. In the init isolate, call [IsolateManagerServer.register] with the server isolate's ID
+///    and send port to complete the registration process.
+/// 5. When a client isolate connects via [IsolateManagerClient.connect], the manager forwards
+///    an [IsolateConnectionRequest] to this server. The helper stores the client's send port
+///    and responds with an [IsolateConnectionResponse] containing this server's receive port.
+/// 6. When a client sends a command via [IsolateManagerClient.sendCommand], the helper receives
+///    a [ClientCommand] and calls [commandHandler] with the command data. The handler should
+///    return a value of type [R], which the helper wraps in a [ServerResponse] and sends back
+///    to the client isolate.
 class ServerIsolateHelper<C, R> {
   /// The isolate ID of this server isolate.
   final String isolateId;
@@ -90,7 +97,12 @@ class ServerIsolateHelper<C, R> {
     }
   }
 
-  /// Handle starting up the server isolate, sending the startup message to the init isolate.
+  /// Handle starting up the server isolate by registering with the IsolateManagerServer.
+  ///
+  /// Sends an [IsolateRegistrationRequest] to the manager isolate and waits for
+  /// an [IsolateRegistrationResponse] to confirm registration.
+  ///
+  /// [managerSendPort] is a send port that sends to the IsolateManagerServer's receive port.
   Future<void> handleStartup(SendPort managerSendPort) async {
     _clientSendPorts[IsolateManagerServer.id] = managerSendPort;
     _log.i("Server isolate $isolateId registering with manager isolate");

--- a/lib/server/isolate/isolate_server_helper.dart
+++ b/lib/server/isolate/isolate_server_helper.dart
@@ -33,6 +33,8 @@ typedef ServerCommandHandler<C, R> = Future<R> Function(C command);
 ///    return a value of type [R], which the helper wraps in a [ServerResponse] and sends back
 ///    to the client isolate.
 class ServerIsolateHelper<C, R> {
+  static bool verboseLogging = false;
+
   /// The isolate ID of this server isolate.
   final String isolateId;
   /// The send ports of the client isolates that are connected to this server isolate.
@@ -57,7 +59,11 @@ class ServerIsolateHelper<C, R> {
     if(message is! IsolateMessage) {
       throw Exception("Invalid message type: ${message.runtimeType}");
     }
-    else if(message is IsolateRegistrationResponse) {
+
+    if(verboseLogging) {
+      _log.i("${message.runtimeType}: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+    }
+    if(message is IsolateRegistrationResponse) {
       _log.i("Registered with manager isolate");
       // Servers only receive messages from the manager isolate, but
       // just in case that pattern changes...
@@ -103,10 +109,10 @@ class ServerIsolateHelper<C, R> {
   /// an [IsolateRegistrationResponse] to confirm registration.
   ///
   /// [managerSendPort] is a send port that sends to the IsolateManagerServer's receive port.
-  Future<void> handleStartup(SendPort managerSendPort) async {
-    _clientSendPorts[IsolateManagerServer.id] = managerSendPort;
+  Future<void> handleStartup({required IsolateStartData startData}) async {
+    _clientSendPorts[IsolateManagerServer.id] = startData.managerPort!;
     _log.i("Server isolate $isolateId registering with manager isolate");
-    managerSendPort.send(
+    startData.managerPort!.send(
       IsolateRegistrationRequest(
         sourceIsolateId: isolateId,
         destinationIsolateId: IsolateManagerServer.id,
@@ -114,5 +120,7 @@ class ServerIsolateHelper<C, R> {
       )
     );
     await _registeredCompleter.future;
+
+    startData.initPort.send(StartupCompleteResponse(sourceIsolateId: isolateId));
   }
 }

--- a/lib/server/isolate/isolate_server_helper.dart
+++ b/lib/server/isolate/isolate_server_helper.dart
@@ -1,0 +1,106 @@
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:shooting_sports_analyst/logger.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_manager.dart';
+import 'package:shooting_sports_analyst/server/isolate/isolate_messages.dart';
+
+final _log = SSALogger("ServerIsolateHelper");
+
+typedef ServerCommandHandler<C, R> = Future<R> Function(C command);
+
+/// A helper for server isolates that handles communication with client isolates,
+/// including the IsolateManagerServer, and handles converting server isolate-specific
+/// data types to and from the generic [IsolateMessage] types.
+///
+/// [C] is the client command data type for this server isolate.
+/// [R] is the server response datatype for this server isolate.
+///
+/// To use:
+/// 1. Spawn your server isolate, passing in a send port that sends to the init receive port.
+/// 2. Create an instance of ServerIsolateHelper for your server isolate, and call [handleStartup]
+/// with the send port from the init isolate.
+/// 3. In the init isolate, call [IsolateManagerServer.register] with the send port from the server isolate.
+/// 4. [commandHandler] will be called when a command is received from a client isolate.
+/// 5. [commandHandler] should return a [ServerResponse] object.
+/// 6. The [ServerResponse] object will be sent back to the client isolate that sent the command.
+class ServerIsolateHelper<C, R> {
+  /// The isolate ID of this server isolate.
+  final String isolateId;
+  /// The send ports of the client isolates that are connected to this server isolate.
+  final Map<String, SendPort> _clientSendPorts = {};
+  /// The receive port of this server isolate.
+  final ReceivePort _receivePort = ReceivePort();
+
+  /// The handler for commands from client isolates.
+  final ServerCommandHandler<C, R> commandHandler;
+
+  final Completer<bool> _registeredCompleter = Completer();
+  Future<bool> get registered => _registeredCompleter.future;
+
+  ServerIsolateHelper({
+    required this.isolateId,
+    required this.commandHandler,
+  }) {
+    _receivePort.listen(_listen);
+  }
+
+  void _listen(dynamic message) async{
+    if(message is! IsolateMessage) {
+      throw Exception("Invalid message type: ${message.runtimeType}");
+    }
+    else if(message is IsolateRegistrationResponse) {
+      _log.i("Registered with manager isolate");
+      // Servers only receive messages from the manager isolate, but
+      // just in case that pattern changes...
+      _clientSendPorts[IsolateManagerServer.id] = message.sendPort;
+      _registeredCompleter.complete(true);
+    }
+    else if(message is IsolateConnectionRequest) {
+      _log.i("Connected to client isolate ${message.sourceIsolateId}");
+      _clientSendPorts[message.sourceIsolateId] = message.sendPort;
+      _clientSendPorts[message.sourceIsolateId]!.send(
+        IsolateConnectionResponse(
+          sourceIsolateId: isolateId,
+          destinationIsolateId: message.sourceIsolateId,
+          sendPort: _receivePort.sendPort,
+        )
+      );
+    }
+    else if(message is ClientCommand<C>) {
+      var response = await commandHandler(message.data);
+      _clientSendPorts[message.sourceIsolateId]!.send(
+        ServerResponse<R>(
+          sourceIsolateId: isolateId,
+          destinationIsolateId: message.sourceIsolateId,
+          data: response,
+        )
+      );
+    }
+    else if(message is ClientCommand) {
+      _log.w("Received incorrect client command type: ${message.runtimeType}");
+      _log.i("IsolateMessage: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+      _clientSendPorts[message.sourceIsolateId]!.send(null);
+    }
+    else {
+      _log.w("Received unexpected message from client isolate: ${message.runtimeType}");
+      _log.i("IsolateMessage: ${message.sourceIsolateId} -> ${message.destinationIsolateId}");
+      _clientSendPorts[message.sourceIsolateId]!.send(null);
+    }
+  }
+
+  /// Handle starting up the server isolate, sending the startup message to the init isolate.
+  Future<void> handleStartup(SendPort managerSendPort) async {
+    _clientSendPorts[IsolateManagerServer.id] = managerSendPort;
+    _log.i("Server isolate $isolateId registering with manager isolate");
+    managerSendPort.send(
+      IsolateRegistrationRequest(
+        sourceIsolateId: isolateId,
+        destinationIsolateId: IsolateManagerServer.id,
+        sendPort: _receivePort.sendPort,
+      )
+    );
+    await _registeredCompleter.future;
+  }
+}

--- a/lib/server/matches/match_service.dart
+++ b/lib/server/matches/match_service.dart
@@ -55,7 +55,7 @@ class MatchService {
     if(match == null) {
       return Response.notFound("Match not found");
     }
-    var hydratedRes = match.hydrate();
+    var hydratedRes = await match.hydrate();
     if(hydratedRes.isErr()) {
       return Response.internalServerError(body: "Failed to hydrate match");
     }

--- a/lib/server/providers.dart
+++ b/lib/server/providers.dart
@@ -11,12 +11,15 @@ import 'package:shooting_sports_analyst/config/serialized_config.dart';
 import 'package:shooting_sports_analyst/flutter_native_providers.dart';
 import 'package:shooting_sports_analyst/logger.dart';
 
-class ServerDebugProvider implements DebugModeProvider {
+class ServerDebugProvider implements DebugModeProvider, ServerModeProvider {
   @override
   bool get kDebugMode => true;
 
   @override
   bool get kReleaseMode => false;
+
+  @override
+  bool get kServerMode => true;
 }
 
 class ServerConfigProvider implements ConfigProvider {

--- a/lib/ui/database/match/match_db_list_view.dart
+++ b/lib/ui/database/match/match_db_list_view.dart
@@ -78,7 +78,7 @@ class _MatchDatabaseListViewState extends State<MatchDatabaseListView> {
                     onTap: () async {
                       var ratingsContext = context.read<RatingContext>();
                       var ratings = await ratingsContext.getProject();
-                      var fullMatchResult = match.hydrate();
+                      var fullMatchResult = await match.hydrate();
                       if(fullMatchResult.isErr()) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(content: Text("Unable to load match from database"))

--- a/lib/ui/prediction_game/widget/prediction_game_match_list.dart
+++ b/lib/ui/prediction_game/widget/prediction_game_match_list.dart
@@ -56,8 +56,13 @@ class PredictionGameMatchList extends StatelessWidget {
                   child: IconButton(
                     icon: Icon(Icons.scoreboard_outlined),
                     onPressed: () async {
+                      var match = await matchResult.hydrate();
+                      if(match.isErr()) {
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Failed to hydrate match.")));
+                        return;
+                      }
                       Navigator.of(context).push(MaterialPageRoute(builder: (context) => ResultPage(
-                        canonicalMatch: matchResult.hydrate().unwrap(),
+                        canonicalMatch: match.unwrap(),
                         ratings: ratings,
                       )));
                     }

--- a/lib/ui/prediction_game/widget/wager_list.dart
+++ b/lib/ui/prediction_game/widget/wager_list.dart
@@ -7,6 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shooting_sports_analyst/config/config.dart';
+import 'package:shooting_sports_analyst/data/cache/match/match_cache.dart';
 import 'package:shooting_sports_analyst/data/database/analyst_database.dart';
 import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/schema/match_prep/match_prep.dart';
@@ -24,13 +25,68 @@ final _log = SSALogger("WagerList");
 /// A list of wagers for a prediction game, match prep, or prediction game player.
 ///
 /// Requires a [WagerListModel] to be provided.
-class WagerList extends StatelessWidget {
+class WagerList extends StatefulWidget {
   WagerList({super.key, this.trailingWidth, this.dimResolvedWagers = true});
 
   final double? trailingWidth;
   final bool dimResolvedWagers;
 
+  @override
+  State<WagerList> createState() => _WagerListState();
+}
+
+class _WagerListState extends State<WagerList> {
   final db = AnalystDatabase();
+
+  late WagerListModel _model;
+  bool _loadingScores = false;
+  String? _matchPrepName;
+  ShootingMatch? _matchResult;
+  Map<DbWager, WagerScores>? _relevantScoresMap;
+
+  @override
+  void initState() {
+    super.initState();
+    var model = context.read<WagerListModel>();
+    _model = model;
+    _model.addListener(_loadScores);
+    _loadScores();
+  }
+
+  Future<void> _loadScores() async {
+    if(_loadingScores) {
+      return;
+    }
+    _loadingScores = true;
+    final futureMatch = _model.matchPrep?.futureMatch.value;
+    _matchPrepName = futureMatch?.eventName;
+    if(futureMatch != null) {
+      var dbMatchResult = futureMatch.dbMatch.value;
+      if(dbMatchResult != null) {
+        var result = MatchCache.inMemoryInstance.get(dbMatchResult);
+        if(result.isOk()) {
+          _matchResult = result.unwrap();
+        }
+      }
+    }
+
+    Map<DbWager, ShootingMatch> matches = {};
+    if(_matchResult != null) {
+      for(var wager in _model.wagers) {
+        matches[wager] = _matchResult!;
+      }
+    }
+    _relevantScoresMap = await _model.managerModel.manager.getAllRelevantScores(_model.wagers, matches: matches);
+    setState(() {
+      _loadingScores = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _model.removeListener(_loadScores);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -42,27 +98,8 @@ class WagerList extends StatelessWidget {
     bool showPlayer = model.player == null;
     bool showMatchName = model.matchPrep == null;
 
-    final futureMatch = model.matchPrep?.futureMatch.value;
-    final matchPrepName = futureMatch?.eventName;
-    ShootingMatch? matchResult;
-    if(futureMatch != null) {
-      var dbMatchResult = futureMatch.dbMatch.value;
-      if(dbMatchResult != null) {
-        var result = HydratedMatchCache().get(dbMatchResult);
-        if(result.isOk()) {
-          matchResult = result.unwrap();
-        }
-      }
-    }
-
-    Map<DbWager, WagerScores> relevantScoresMap = {};
-
-    if(matchResult != null) {
-      Map<DbWager, ShootingMatch> matches = {};
-      for(var wager in model.wagers) {
-        matches[wager] = matchResult;
-      }
-      relevantScoresMap = model.managerModel.manager.getAllRelevantScores(model.wagers, matches: matches);
+    if(_loadingScores) {
+      return const Center(child: CircularProgressIndicator());
     }
 
     var listView = ListView.builder(
@@ -120,7 +157,7 @@ class WagerList extends StatelessWidget {
         }
         if(showMatchName) {
           subtitleText.add(
-            Expanded(flex: 6, child: Text(matchPrepName ?? "", overflow: TextOverflow.ellipsis)),
+            Expanded(flex: 6, child: Text(_matchPrepName ?? "", overflow: TextOverflow.ellipsis)),
           );
         }
 
@@ -140,8 +177,8 @@ class WagerList extends StatelessWidget {
         bool hitsOnPredictionSetResult = false;
         Map<DbPrediction, bool>? legResults;
         Map<DbPrediction, bool>? predictionSetLegResults;
-        WagerScores? relevantScores = relevantScoresMap[wager];
-        if(matchResult != null && relevantScores != null) {
+        WagerScores? relevantScores = _relevantScoresMap?[wager];
+        if(_matchResult != null && relevantScores != null) {
           legResults = wager.evaluateLegs(relevantScores.scores);
           predictionSetLegResults = wager.evaluateLegs(relevantScores.predictionSetScores);
           hitsOnMainResult = legResults.entries.every((e) => e.value);
@@ -166,7 +203,7 @@ class WagerList extends StatelessWidget {
             trailing.add(Text(scoreText));
           }
         }
-        if(canResolve && matchResult != null && wager.isOpen) {
+        if(canResolve && _matchResult != null && wager.isOpen) {
           String mainResolveMessage = ", for a house profit of ${wager.amount.toStringAsFixed(2)}";
           if(hitsOnMainResult) {
             mainResolveMessage = ", paying out ${wager.payout().toStringAsFixed(2)} to ${wager.user.value!.nickname}";
@@ -262,14 +299,14 @@ class WagerList extends StatelessWidget {
           trailingWidget = const SizedBox.shrink();
         }
 
-        if(trailingWidth != null) {
+        if(widget.trailingWidth != null) {
           trailingWidget = SizedBox(
-            width: trailingWidth! * uiScaleFactor,
+            width: widget.trailingWidth! * uiScaleFactor,
             child: trailingWidget,
           );
         }
 
-        bool disabled = dimResolvedWagers && !wager.isOpen;
+        bool disabled = widget.dimResolvedWagers && !wager.isOpen;
         return ListTile(
           enabled: !disabled,
           title: descriptionText,

--- a/lib/ui/prematch/widget/match_prep_predictions.dart
+++ b/lib/ui/prematch/widget/match_prep_predictions.dart
@@ -4,12 +4,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shooting_sports_analyst/config/config.dart';
+import 'package:shooting_sports_analyst/data/database/match/hydrated_cache.dart';
 import 'package:shooting_sports_analyst/data/database/schema/match_prep/prediction_set.dart';
 import 'package:shooting_sports_analyst/data/database/schema/ratings.dart';
+import 'package:shooting_sports_analyst/data/ranking/model/rating_system.dart';
 import 'package:shooting_sports_analyst/data/ranking/prediction/match_prediction.dart';
+import 'package:shooting_sports_analyst/data/sport/shooter/filter_set.dart';
 import 'package:shooting_sports_analyst/logger.dart';
 import 'package:shooting_sports_analyst/ui/prematch/match_prep_model.dart';
 import 'package:shooting_sports_analyst/ui/rater/prediction/prediction_view.dart';
@@ -217,7 +221,40 @@ class _PredictionSetTabState extends State<_PredictionSetTab> {
     lastPredictionSetId = outerModel.selectedPredictionSet?.id ?? 0;
     lastRatingGroupUuid = widget.group.uuid;
     var groupPredictions = outerModel.getPredictionsForGroup(widget.group);
-    model = PredictionViewModel(matchId: outerModel.matchPrepModel.futureMatch.matchId, initialPredictions: groupPredictions, showWager: true);
+    model = PredictionViewModel(
+      matchId: outerModel.matchPrepModel.futureMatch.matchId,
+      initialPredictions: groupPredictions,
+      showWager: true,
+    );
+    _updateOutcomes(outerModel);
+  }
+
+  Future<void> _updateOutcomes(_MatchPrepPredictionsModel outerModel) async {
+    if(outerModel.matchPrepModel.futureMatch.dbMatch.value != null) {
+      var matchRes = HydratedMatchCache().get(outerModel.matchPrepModel.futureMatch.dbMatch.value!);
+      if(matchRes.isOk()) {
+        Map<AlgorithmPrediction, SimpleMatchResult> outcomes = {};
+        var match = matchRes.unwrap();
+        var filters = widget.group.filters;
+        var shooters = match.filterShooters(
+          filterMode: FilterMode.and,
+          divisions: filters.activeDivisions.toList(),
+          allowReentries: false,
+        );
+        var scores = match.getScores(
+          shooters: shooters,
+          scoreDQ: false,
+        );
+        for(var prediction in model.predictions) {
+          var score = scores.entries
+            .firstWhereOrNull((element) => element.key.equalsShooter(prediction.shooter))?.value;
+          if(score != null) {
+            outcomes[prediction] = SimpleMatchResult(raterScore: prediction.mean, percent: score.ratio, place: score.place);
+          }
+        }
+        model.setOutcomes(outcomes);
+      }
+    }
   }
 
   void updatePredictionViewModel(_MatchPrepPredictionsModel outerModel) {

--- a/lib/ui/rater/prediction/prediction_view.dart
+++ b/lib/ui/rater/prediction/prediction_view.dart
@@ -175,7 +175,7 @@ class _PredictionListViewScreenState extends State<PredictionListViewScreen> {
     );
     if(dbMatch == null) return;
 
-    var matchRes = dbMatch.hydrate(useCache: true);
+    var matchRes = dbMatch.hydrateSync(useCache: true);
 
     if(matchRes.isErr()) {
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(matchRes.unwrapErr().message)));

--- a/test/api/miff/miff_test.dart
+++ b/test/api/miff/miff_test.dart
@@ -45,7 +45,7 @@ void main() {
         var dbMatch = await db.getMatchByAnySourceId([matchId]);
         expect(dbMatch, isNotNull, reason: "Match $matchId should exist in database");
 
-        var originalMatch = dbMatch!.hydrate().unwrap();
+        var originalMatch = dbMatch!.hydrateSync().unwrap();
 
         // Export to MIFF
         var miffBytes = await exportToMiff(originalMatch);
@@ -63,7 +63,7 @@ void main() {
         var dbMatch = await db.getMatchByAnySourceId([matchId]);
         expect(dbMatch, isNotNull, reason: "Match $matchId should exist in database");
 
-        var originalMatch = dbMatch!.hydrate().unwrap();
+        var originalMatch = dbMatch!.hydrateSync().unwrap();
 
         var _ = DbShootingMatch.from(originalMatch);
 
@@ -89,7 +89,7 @@ void main() {
         var dbMatch = await db.getMatchByAnySourceId([matchId]);
         expect(dbMatch, isNotNull, reason: "Match $matchId should exist in database");
 
-        var originalMatch = dbMatch!.hydrate().unwrap();
+        var originalMatch = dbMatch!.hydrateSync().unwrap();
 
         // First export/import cycle
         var miffBytes1 = await exportToMiff(originalMatch);
@@ -117,7 +117,7 @@ void main() {
         var dbMatch = await db.getMatchByAnySourceId([matchId]);
         expect(dbMatch, isNotNull, reason: "Match $matchId should exist in database");
 
-        var originalMatch = dbMatch!.hydrate().unwrap();
+        var originalMatch = dbMatch!.hydrateSync().unwrap();
         var miffBytes = await exportToMiff(originalMatch);
 
         // Test validate() method

--- a/test/database/save_match_sync_test.dart
+++ b/test/database/save_match_sync_test.dart
@@ -61,7 +61,7 @@ void main() {
       expect(retrievedMatchAsync, isNotNull, reason: "Retrieved match should be retrievable by database ID");
       expect(retrievedMatchAsync!.eventName, equals(match.name), reason: "Retrieved match name should match");
 
-      var hydratedResultAsync = retrievedMatchAsync.hydrate();
+      var hydratedResultAsync = retrievedMatchAsync.hydrateSync();
       expect(hydratedResultAsync.isOk(), isTrue, reason: "Match should hydrate successfully");
       var hydratedMatchAsync = hydratedResultAsync.unwrap();
       expect(hydratedMatchAsync.shooters, isNotEmpty, reason: "Hydrated match should have competitors after saveMatchSync");
@@ -80,7 +80,7 @@ void main() {
       expect(retrievedMatch!.eventName, equals(match.name), reason: "Retrieved match name should match");
 
       // KEY CHECK: Load the match from database, hydrate it, and verify it has competitors
-      var hydratedResult = retrievedMatch.hydrate();
+      var hydratedResult = retrievedMatch.hydrateSync();
       expect(hydratedResult.isOk(), isTrue, reason: "Match should hydrate successfully");
       var hydratedMatch = hydratedResult.unwrap();
       expect(hydratedMatch.shooters, isNotEmpty, reason: "Hydrated match should have competitors after saveMatchSync");
@@ -93,7 +93,7 @@ void main() {
       expect(retrievedById!.eventName, equals(match.name), reason: "Retrieved match name should match");
 
       // Also hydrate and check the one retrieved by ID
-      var hydratedByIdResult = retrievedById.hydrate();
+      var hydratedByIdResult = retrievedById.hydrateSync();
       expect(hydratedByIdResult.isOk(), isTrue, reason: "Match retrieved by ID should hydrate successfully");
       var hydratedById = hydratedByIdResult.unwrap();
       expect(hydratedById.shooters, isNotEmpty, reason: "Hydrated match (by ID) should have competitors");
@@ -158,7 +158,7 @@ void main() {
       expect(retrievedMatch, isNotNull);
 
       // Hydrate the match to access shooters
-      var hydratedResult = retrievedMatch!.hydrate();
+      var hydratedResult = retrievedMatch!.hydrateSync();
       expect(hydratedResult.isOk(), isTrue, reason: "Match should hydrate successfully");
       var hydratedMatch = hydratedResult.unwrap();
       expect(hydratedMatch.shooters.length, equals(match.shooters.length),

--- a/test/rater/icore_deduplication_test.dart
+++ b/test/rater/icore_deduplication_test.dart
@@ -481,7 +481,7 @@ Future<List<DbShooterRating>> addMatchToTest(AnalystDatabase db, DbRatingProject
   project.matchPointers.add(MatchPointer.fromDbMatch(dbMatch!));
 
   await db.saveRatingProject(project);
-  var match = dbMatch.hydrate().unwrap();
+  var match = dbMatch.hydrateSync().unwrap();
 
   List<DbShooterRating> newRatings = [];
   for(var competitor in match.shooters) {

--- a/test/rater/typo_deduplication_test.dart
+++ b/test/rater/typo_deduplication_test.dart
@@ -135,7 +135,7 @@ Future<List<DbShooterRating>> addMatchToTest(AnalystDatabase db, DbRatingProject
   project.matchPointers.add(MatchPointer.fromDbMatch(dbMatch!));
 
   await db.saveRatingProject(project);
-  var match = dbMatch.hydrate().unwrap();
+  var match = dbMatch.hydrateSync().unwrap();
 
   List<DbShooterRating> newRatings = [];
   for(var competitor in match.shooters) {

--- a/test/rater/uspsa_deduplication_test.dart
+++ b/test/rater/uspsa_deduplication_test.dart
@@ -1187,7 +1187,7 @@ Future<List<DbShooterRating>> addMatchToTest(AnalystDatabase db, DbRatingProject
   project.matchPointers.add(MatchPointer.fromDbMatch(dbMatch!));
 
   await db.saveRatingProject(project);
-  var match = dbMatch.hydrate().unwrap();
+  var match = dbMatch.hydrateSync().unwrap();
 
   List<DbShooterRating> newRatings = [];
   for(var competitor in match.shooters) {


### PR DESCRIPTION
For the Analyst website server, there are going to be a few places where I want to have certain things cached in memory, but I only want one copy even if I'm using multiple isolates to serve web requests. This pattern allows the website (and other similar multi-isolate contexts) to create 'server isolates' to which worker threads can connect as clients.